### PR TITLE
Fix vulnerability metadata table

### DIFF
--- a/pkg/db/v1/model/vulnerability.go
+++ b/pkg/db/v1/model/vulnerability.go
@@ -12,8 +12,9 @@ const (
 )
 
 type VulnerabilityModel struct {
-	ID                   string `gorm:"primary_key; column:id"`
-	RecordSource         string `gorm:"primary_key; column:record_source"`
+	PK                   uint64 `gorm:"primary_key;auto_increment;"`
+	ID                   string `gorm:"column:id"`
+	RecordSource         string `gorm:"column:record_source"`
 	PackageName          string `gorm:"column:package_name; index:get_vulnerability_index"`
 	Namespace            string `gorm:"column:namespace; index:get_vulnerability_index"`
 	VersionConstraint    string `gorm:"column:version_constraint"`

--- a/pkg/db/v1/model/vulnerability_metadata.go
+++ b/pkg/db/v1/model/vulnerability_metadata.go
@@ -13,13 +13,13 @@ const (
 )
 
 type VulnerabilityMetadataModel struct {
-	ID           string         `gorm:"primary_key; column: id;"`
-	RecordSource string         `gorm:"primary_key; column: record_source;"`
-	Severity     string         `gorm:"column: severity"`
-	Links        string         `gorm:"column: links"`
-	Description  string         `gorm:"column: description"`
-	CvssV2       sql.NullString `gorm:"column: cvss_v2"`
-	CvssV3       sql.NullString `gorm:"column: cvss_v3"`
+	ID           string         `gorm:"primary_key; column:id;"`
+	RecordSource string         `gorm:"primary_key; column:record_source;"`
+	Severity     string         `gorm:"column:severity"`
+	Links        string         `gorm:"column:links"`
+	Description  string         `gorm:"column:description"`
+	CvssV2       sql.NullString `gorm:"column:cvss_v2"`
+	CvssV3       sql.NullString `gorm:"column:cvss_v3"`
 }
 
 func (VulnerabilityMetadataModel) TableName() string {

--- a/pkg/db/v1/writer/store.go
+++ b/pkg/db/v1/writer/store.go
@@ -98,9 +98,9 @@ func (s *Store) AddVulnerability(vulnerabilities ...*v1.Vulnerability) error {
 		if vulnerability == nil {
 			continue
 		}
-		model := model.NewVulnerabilityModel(*vulnerability)
+		m := model.NewVulnerabilityModel(*vulnerability)
 
-		result := s.vulnDb.Create(&model)
+		result := s.vulnDb.Create(&m)
 		if result.Error != nil {
 			return result.Error
 		}

--- a/pkg/db/v1/writer/store_test.go
+++ b/pkg/db/v1/writer/store_test.go
@@ -183,13 +183,13 @@ func assertVulnerabilityMetadataReader(t *testing.T, reader v1.VulnerabilityMeta
 }
 
 func TestStore_GetVulnerabilityMetadata_SetVulnerabilityMetadata(t *testing.T) {
-	dbTempDir, err := ioutil.TempDir("", "grype-db-test-store")
+	dbTempFile, err := ioutil.TempFile("", "grype-db-test-store")
 	if err != nil {
 		t.Fatalf("could not create temp file: %+v", err)
 	}
-	defer os.RemoveAll(dbTempDir)
+	defer os.Remove(dbTempFile.Name())
 
-	store, cleanupFn, err := NewStore(dbTempDir, true)
+	store, cleanupFn, err := NewStore(dbTempFile.Name(), true)
 	defer cleanupFn()
 	if err != nil {
 		t.Fatalf("could not create store: %+v", err)
@@ -251,7 +251,14 @@ func TestStore_GetVulnerabilityMetadata_SetVulnerabilityMetadata(t *testing.T) {
 		t.Fatalf("unexpected number of entries: %d", len(allEntries))
 	}
 
-	assertVulnerabilityMetadataReader(t, store, total[0].ID, total[0].RecordSource, total[0])
+	// gut check on reader
+	storeReader, othercleanfn, err := reader.NewStore(dbTempFile.Name())
+	defer othercleanfn()
+	if err != nil {
+		t.Fatalf("could not open db reader: %+v", err)
+	}
+
+	assertVulnerabilityMetadataReader(t, storeReader, total[0].ID, total[0].RecordSource, total[0])
 
 }
 


### PR DESCRIPTION
- Replaces the vulnerability table primary key (required since builder now populates the record source field)
- Remove spaces from column names
- Fix metadata table + reader