### PR TITLE
Add fixed-in-version to the vulnerability model

### DIFF
--- a/pkg/db/v1/model/vulnerability.go
+++ b/pkg/db/v1/model/vulnerability.go
@@ -11,6 +11,7 @@ const (
 	GetVulnerabilityIndexName = "get_vulnerability_index"
 )
 
+// VulnerabilityModel is a struct used to serialize v1.Vulnerability information into a sqlite3 DB.
 type VulnerabilityModel struct {
 	PK                   uint64 `gorm:"primary_key;auto_increment;"`
 	ID                   string `gorm:"column:id"`
@@ -21,8 +22,10 @@ type VulnerabilityModel struct {
 	VersionFormat        string `gorm:"column:version_format"`
 	CPEs                 string `gorm:"column:cpes"`
 	ProxyVulnerabilities string `gorm:"column:proxy_vulnerabilities"`
+	FixedInVersion       string `gorm:"column:fixed_in_version"`
 }
 
+// NewVulnerabilityModel generates a new model from a v1.Vulnerability struct.
 func NewVulnerabilityModel(vulnerability v1.Vulnerability) VulnerabilityModel {
 	cpes, err := json.Marshal(vulnerability.CPEs)
 	if err != nil {
@@ -43,15 +46,18 @@ func NewVulnerabilityModel(vulnerability v1.Vulnerability) VulnerabilityModel {
 		Namespace:            vulnerability.Namespace,
 		VersionConstraint:    vulnerability.VersionConstraint,
 		VersionFormat:        vulnerability.VersionFormat,
+		FixedInVersion:       vulnerability.FixedInVersion,
 		CPEs:                 string(cpes),
 		ProxyVulnerabilities: string(proxy),
 	}
 }
 
+// TableName returns the table which all v1.Vulnerability model instances are stored into.
 func (VulnerabilityModel) TableName() string {
 	return VulnerabilityTableName
 }
 
+// Inflate generates a v1.Vulnerability object from the serialized model instance.
 func (m *VulnerabilityModel) Inflate() v1.Vulnerability {
 	var cpes []string
 	err := json.Unmarshal([]byte(m.CPEs), &cpes)
@@ -76,5 +82,6 @@ func (m *VulnerabilityModel) Inflate() v1.Vulnerability {
 		VersionFormat:        m.VersionFormat,
 		CPEs:                 cpes,
 		ProxyVulnerabilities: proxy,
+		FixedInVersion:       m.FixedInVersion,
 	}
 }

--- a/pkg/db/v1/model/vulnerability_metadata.go
+++ b/pkg/db/v1/model/vulnerability_metadata.go
@@ -12,6 +12,7 @@ const (
 	VulnerabilityMetadataTableName = "vulnerability_metadata"
 )
 
+// VulnerabilityMetadataModel is a struct used to serialize v1.VulnerabilityMetadata information into a sqlite3 DB.
 type VulnerabilityMetadataModel struct {
 	ID           string         `gorm:"primary_key; column:id;"`
 	RecordSource string         `gorm:"primary_key; column:record_source;"`
@@ -22,10 +23,7 @@ type VulnerabilityMetadataModel struct {
 	CvssV3       sql.NullString `gorm:"column:cvss_v3"`
 }
 
-func (VulnerabilityMetadataModel) TableName() string {
-	return VulnerabilityMetadataTableName
-}
-
+// NewVulnerabilityMetadataModel generates a new model from a v1.VulnerabilityMetadata struct.
 func NewVulnerabilityMetadataModel(metadata v1.VulnerabilityMetadata) VulnerabilityMetadataModel {
 	links, err := json.Marshal(metadata.Links)
 	if err != nil {
@@ -66,18 +64,23 @@ func NewVulnerabilityMetadataModel(metadata v1.VulnerabilityMetadata) Vulnerabil
 	}
 }
 
+// TableName returns the table which all v1.VulnerabilityMetadata model instances are stored into.
+func (VulnerabilityMetadataModel) TableName() string {
+	return VulnerabilityMetadataTableName
+}
+
+// Inflate generates a v1.VulnerabilityMetadataModel object from the serialized model instance.
 func (m *VulnerabilityMetadataModel) Inflate() v1.VulnerabilityMetadata {
 	var links []string
 	var cvssV2, cvssV3 *v1.Cvss
 
-	err := json.Unmarshal([]byte(m.Links), &links)
-	if err != nil {
+	if err := json.Unmarshal([]byte(m.Links), &links); err != nil {
 		// TODO: just no
 		panic(fmt.Errorf("%w: %+v", err, m.Links))
 	}
 
 	if m.CvssV2.Valid {
-		err = json.Unmarshal([]byte(m.CvssV2.String), &cvssV2)
+		err := json.Unmarshal([]byte(m.CvssV2.String), &cvssV2)
 		if err != nil {
 			// TODO: just no
 			panic(fmt.Errorf("%w: %+v", err, m.CvssV2.String))
@@ -85,7 +88,7 @@ func (m *VulnerabilityMetadataModel) Inflate() v1.VulnerabilityMetadata {
 	}
 
 	if m.CvssV3.Valid {
-		err = json.Unmarshal([]byte(m.CvssV3.String), &cvssV3)
+		err := json.Unmarshal([]byte(m.CvssV3.String), &cvssV3)
 		if err != nil {
 			// TODO: just no
 			panic(fmt.Errorf("%w: %+v", err, m.CvssV3.String))

--- a/pkg/db/v1/vulnerability.go
+++ b/pkg/db/v1/vulnerability.go
@@ -2,12 +2,13 @@ package v1
 
 // Vulnerability represents the minimum data fields necessary to perform package-to-vulnerability matching. This can represent a CVE, 3rd party advisory, or any source that relates back to a CVE.
 type Vulnerability struct {
-	ID                   string
-	RecordSource         string
-	PackageName          string
-	Namespace            string
-	VersionConstraint    string
-	VersionFormat        string
-	CPEs                 []string
-	ProxyVulnerabilities []string
+	ID                   string   // The identifier of the vulnerability or advisory
+	RecordSource         string   // The source of the vulnerability information
+	PackageName          string   // The name of the package that is vulnerable
+	Namespace            string   // The ecosystem where the package resides
+	VersionConstraint    string   // The version range which the given package is vulnerable
+	VersionFormat        string   // The format which all version fields should be interpreted as
+	CPEs                 []string // The CPEs which are considered vulnerable
+	ProxyVulnerabilities []string // IDs of other Vulnerabilities that are related to this one (this is how advisories relate to CVEs)
+	FixedInVersion       string   // The version which this particular vulnerability was fixed in
 }

--- a/pkg/db/v1/vulnerability_metadata.go
+++ b/pkg/db/v1/vulnerability_metadata.go
@@ -2,18 +2,19 @@ package v1
 
 // VulnerabilityMetadata represents all vulnerability data that is not necessary to perform package-to-vulnerability matching.
 type VulnerabilityMetadata struct {
-	ID           string
-	RecordSource string
-	Severity     string
-	Links        []string
-	Description  string
-	CvssV2       *Cvss
-	CvssV3       *Cvss
+	ID           string   // The identifier of the vulnerability or advisory
+	RecordSource string   // The source of the vulnerability information
+	Severity     string   // How severe the vulnerability is (valid values are defined by upstream sources currently)
+	Links        []string // URLs to get more information about the vulnerability or advisory
+	Description  string   // Description of the vulnerability
+	CvssV2       *Cvss    // Common Vulnerability Scoring System V2 values
+	CvssV3       *Cvss    // Common Vulnerability Scoring System V3 values
 }
 
+// Cvss contains select Common Vulnerability Scoring System fields for a vulnerability.
 type Cvss struct {
-	BaseScore           float64
-	ExploitabilityScore float64
-	ImpactScore         float64
-	Vector              string
+	BaseScore           float64 // Ranges from 0 - 10 and defines for qualities intrinsic to a vulnerability
+	ExploitabilityScore float64 // Indicator of how easy it may be for an attacker to exploit a vulnerability
+	ImpactScore         float64 // Representation of the effects of an exploited vulnerability relative to compromise in confidentiality, integrity, and availability
+	Vector              string  // A textual representation of the metric values used to determine the score
 }

--- a/pkg/db/v1/writer/store.go
+++ b/pkg/db/v1/writer/store.go
@@ -22,9 +22,10 @@ type Store struct {
 	vulnDb *gorm.DB
 }
 
+// CleanupFn is a callback for closing a DB connection.
 type CleanupFn func() error
 
-// NewStore creates a new instance of the store
+// NewStore creates a new instance of the store.
 func NewStore(dbFilePath string, overwrite bool) (*Store, CleanupFn, error) {
 	vulnDbObj, err := open(config{
 		DbPath:    dbFilePath,
@@ -44,6 +45,7 @@ func NewStore(dbFilePath string, overwrite bool) (*Store, CleanupFn, error) {
 	}, vulnDbObj.Close, nil
 }
 
+// GetID fetches the metadata about the databases schema version and build time.
 func (s *Store) GetID() (*v1.ID, error) {
 	var models []model.IDModel
 	result := s.vulnDb.Find(&models)
@@ -62,6 +64,7 @@ func (s *Store) GetID() (*v1.ID, error) {
 	return nil, nil
 }
 
+// SetID stores the databases schema version and build time.
 func (s *Store) SetID(id v1.ID) error {
 	var ids []model.IDModel
 
@@ -78,7 +81,7 @@ func (s *Store) SetID(id v1.ID) error {
 	return result.Error
 }
 
-// Get retrieves one or more vulnerabilities given a namespace and package name
+// GetVulnerability retrieves one or more vulnerabilities given a namespace and package name.
 func (s *Store) GetVulnerability(namespace, packageName string) ([]v1.Vulnerability, error) {
 	var models []model.VulnerabilityModel
 
@@ -92,7 +95,7 @@ func (s *Store) GetVulnerability(namespace, packageName string) ([]v1.Vulnerabil
 	return vulnerabilities, result.Error
 }
 
-// AddVulnerability saves a vulnerability in the sqlite3 store
+// AddVulnerability saves one or more vulnerabilities into the sqlite3 store.
 func (s *Store) AddVulnerability(vulnerabilities ...*v1.Vulnerability) error {
 	for _, vulnerability := range vulnerabilities {
 		if vulnerability == nil {
@@ -112,6 +115,7 @@ func (s *Store) AddVulnerability(vulnerabilities ...*v1.Vulnerability) error {
 	return nil
 }
 
+// GetVulnerabilityMetadata retrieves metadata for the given vulnerability ID relative to a specific record source.
 func (s *Store) GetVulnerabilityMetadata(id, recordSource string) (*v1.VulnerabilityMetadata, error) {
 	var models []model.VulnerabilityMetadataModel
 
@@ -132,6 +136,7 @@ func (s *Store) GetVulnerabilityMetadata(id, recordSource string) (*v1.Vulnerabi
 }
 
 // nolint:gocognit,funlen
+// AddVulnerabilityMetadata stores one or more vulnerability metadata models into the sqlite DB.
 func (s *Store) AddVulnerabilityMetadata(metadata ...*v1.VulnerabilityMetadata) error {
 	for _, m := range metadata {
 		if m == nil {

--- a/pkg/db/v1/writer/store_test.go
+++ b/pkg/db/v1/writer/store_test.go
@@ -102,6 +102,7 @@ func TestStore_GetVulnerability_SetVulnerability(t *testing.T) {
 			VersionFormat:        "semver",
 			CPEs:                 []string{"a-cool-cpe"},
 			ProxyVulnerabilities: []string{"another-cve", "an-other-cve"},
+			FixedInVersion:       "2.0.1",
 		},
 		{
 			ID:                   "my-other-cve-33333",
@@ -125,6 +126,7 @@ func TestStore_GetVulnerability_SetVulnerability(t *testing.T) {
 			VersionFormat:        "semver",
 			CPEs:                 []string{"a-cool-cpe"},
 			ProxyVulnerabilities: []string{"another-cve", "an-other-cve"},
+			FixedInVersion:       "1.0.1",
 		},
 		{
 			ID:                   "my-other-cve",
@@ -135,6 +137,7 @@ func TestStore_GetVulnerability_SetVulnerability(t *testing.T) {
 			VersionFormat:        "semver",
 			CPEs:                 []string{"a-cool-cpe"},
 			ProxyVulnerabilities: []string{"another-cve", "an-other-cve"},
+			FixedInVersion:       "4.0.5",
 		},
 	}
 


### PR DESCRIPTION
Adds the "Fixed In" version data for each vulnerability. This is different from the existing "Version Constraint" which is an arbitrary expression indicating the range(s) which the package is vulnerable.

Partially addresses https://github.com/anchore/grype/issues/144