### PR TITLE
Add schema check to use GITHUB_BASE_REF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,5 +90,6 @@ check-licenses:
 
 .PHONY: check-schema
 check-schema: ## Ensure that there aren't any accidental changes to the DB schema version
-	@ grep -qHr "const SchemaVersion" pkg || { echo "SchemaVersion constant not found, check must be updated to verify proper version" && exit 1;}
-	@ grep -r "const SchemaVersion" pkg | grep -q "= $(DATABASE_SCHEMA_VERSION)" || { echo "Expected database schema version $(DATABASE_SCHEMA_VERSION) not found. Ensure 'const SchemaVersion = $(DATABASE_SCHEMA_VERSION)' is defined" && exit 1;}
+	@ grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $${GITHUB_BASE_REF#v}" || { echo "Expected GITHUB_BASE_REF ($${GITHUB_BASE_REF#v}) to match database schema ($(DATABASE_SCHEMA_VERSION)) version but did not" && exit 1;}
+	@ grep -qHr "const SchemaVersion" pkg/db/schema_version.go || { echo "SchemaVersion constant not found, check must be updated to verify proper version" && exit 1;}
+	@ grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $(DATABASE_SCHEMA_VERSION)" || { echo "Expected database schema version $(DATABASE_SCHEMA_VERSION) not found. Ensure 'const SchemaVersion = $(DATABASE_SCHEMA_VERSION)' is defined" && exit 1;}

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SUCCESS := $(BOLD)$(GREEN)
 # the quality gate lower threshold for unit test total % coverage (by function statements)
 COVERAGE_THRESHOLD := 55
 # supported database schema
-DATABASE_SCHEMA_VERSION = 2
+DATABASE_SCHEMA_VERSION = 3
 
 ifndef TEMPDIR
     $(error TEMPDIR is not set)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SUCCESS := $(BOLD)$(GREEN)
 # the quality gate lower threshold for unit test total % coverage (by function statements)
 COVERAGE_THRESHOLD := 55
 # supported database schema
-DATABASE_SCHEMA_VERSION = 3
+DATABASE_SCHEMA_VERSION = 2
 
 ifndef TEMPDIR
     $(error TEMPDIR is not set)
@@ -90,14 +90,13 @@ check-licenses:
 
 .PHONY: check-schema
 check-schema: ## Ensure that there aren't any accidental changes to the DB schema version
+	@ grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $(DATABASE_SCHEMA_VERSION)" || { echo "Expected database schema version $(DATABASE_SCHEMA_VERSION) not found" && exit 1;}
+
 	@bash -c '\
 		if [ "$$GITHUB_BASE_REF" == "" ]; then\
 			echo "Empty GITHUB_BASE_REF, skipping..."; \
 		else \
 			grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $${GITHUB_BASE_REF#v}" || { echo "Expected GITHUB_BASE_REF ($${GITHUB_BASE_REF#v}) to match database schema ($(DATABASE_SCHEMA_VERSION)) version but did not" && exit 1;} ;\
+			echo "schema version consistent"; \
 		fi \
 	'
-
-	@ grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $(DATABASE_SCHEMA_VERSION)" || { echo "Expected database schema version $(DATABASE_SCHEMA_VERSION) not found" && exit 1;}
-
-	@ echo "schema consistent"

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ bootstrap: ## Download and install all project dependencies (+ prep tooling in t
 	[ -f "$(TEMPDIR)/bouncer" ] || curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.2.0
 
 .PHONY: static-analysis
-static-analysis: lint check-licenses
+static-analysis: lint check-schema check-licenses
 
 .PHONY: lint
 lint: ## Run gofmt + golangci lint checks
@@ -90,6 +90,14 @@ check-licenses:
 
 .PHONY: check-schema
 check-schema: ## Ensure that there aren't any accidental changes to the DB schema version
-	@ grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $${GITHUB_BASE_REF#v}" || { echo "Expected GITHUB_BASE_REF ($${GITHUB_BASE_REF#v}) to match database schema ($(DATABASE_SCHEMA_VERSION)) version but did not" && exit 1;}
-	@ grep -qHr "const SchemaVersion" pkg/db/schema_version.go || { echo "SchemaVersion constant not found, check must be updated to verify proper version" && exit 1;}
-	@ grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $(DATABASE_SCHEMA_VERSION)" || { echo "Expected database schema version $(DATABASE_SCHEMA_VERSION) not found. Ensure 'const SchemaVersion = $(DATABASE_SCHEMA_VERSION)' is defined" && exit 1;}
+	@bash -c '\
+		if [ "$$GITHUB_BASE_REF" == "" ]; then\
+			echo "Empty GITHUB_BASE_REF, skipping..."; \
+		else \
+			grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $${GITHUB_BASE_REF#v}" || { echo "Expected GITHUB_BASE_REF ($${GITHUB_BASE_REF#v}) to match database schema ($(DATABASE_SCHEMA_VERSION)) version but did not" && exit 1;} ;\
+		fi \
+	'
+
+	@ grep -r "const SchemaVersion" pkg/db/schema_version.go | grep -q "= $(DATABASE_SCHEMA_VERSION)" || { echo "Expected database schema version $(DATABASE_SCHEMA_VERSION) not found" && exit 1;}
+
+	@ echo "schema consistent"

--- a/pkg/db/schema_version.go
+++ b/pkg/db/schema_version.go
@@ -1,3 +1,3 @@
 package db
 
-const SchemaVersion = 3
+const SchemaVersion = 2

--- a/pkg/db/schema_version.go
+++ b/pkg/db/schema_version.go
@@ -1,3 +1,3 @@
 package db
 
-const SchemaVersion = 2
+const SchemaVersion = 3


### PR DESCRIPTION
The schema check is good for checking mismatched schema version relative to an expected value, but is not a good check for remembering to bump the version when the new schema version branch is made. This PR adds a the `GITHUB_BASE_REF`  as a value to test the schema version against --in this way when the PR is opened the check will be able to have enough information to make a validation against the known base branch, which matches the name of the schema.