### PR TITLE
Update MSRC namespace to include product ID

### DIFF
--- a/pkg/db/v3/namespace.go
+++ b/pkg/db/v3/namespace.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	NVDNamespace    = "nvd"
-	MSRCNamespace   = "msrc"
-	VulnDBNamespace = "vulndb"
+	NVDNamespace        = "nvd"
+	MSRCNamespacePrefix = "msrc"
+	VulnDBNamespace     = "vulndb"
 )
 
 func RecordSource(feed, group string) string {
@@ -30,8 +30,8 @@ func NamespaceForFeedGroup(feed, group string) (string, error) {
 		return NVDNamespace, nil
 	case feed == "vulndb" && group == "vulndb:vulnerabilities":
 		return VulnDBNamespace, nil
-	case feed == "microsoft" && strings.HasPrefix(group, "msrc:"):
-		return MSRCNamespace, nil
+	case feed == "microsoft" && strings.HasPrefix(group, MSRCNamespacePrefix+":"):
+		return group, nil
 	}
 	return "", fmt.Errorf("feed=%q group=%q has no namespace mappings", feed, group)
 }
@@ -62,7 +62,7 @@ func NamespaceForDistro(d distro.Distro) string {
 			// XXX this assumes that a major and minor versions will always exist in Segments
 			return fmt.Sprintf("alpine:%d.%d", versionSegments[0], versionSegments[1])
 		case distro.Windows:
-			return MSRCNamespace
+			return fmt.Sprintf("%s:%d", MSRCNamespacePrefix, versionSegments[0])
 		}
 	}
 	return fmt.Sprintf("%s:%s", strings.ToLower(d.Type.String()), d.FullVersion())

--- a/pkg/db/v3/namespace_test.go
+++ b/pkg/db/v3/namespace_test.go
@@ -46,7 +46,7 @@ func Test_NamespaceFromRecordSource(t *testing.T) {
 		{
 			Feed:      "microsoft",
 			Group:     "msrc:11769",
-			Namespace: "msrc",
+			Namespace: "msrc:11769",
 		},
 	}
 
@@ -159,7 +159,7 @@ func Test_NamespaceForDistro(t *testing.T) {
 		{
 			dist:     distro.Windows,
 			version:  "471816",
-			expected: "msrc",
+			expected: "msrc:471816",
 		},
 	}
 


### PR DESCRIPTION
Adds the product ID to the MSRC namespace as a suffix.

(Related to https://github.com/anchore/grype-db-builder/issues/122)