### PR TITLE
Add default language namer

### DIFF
--- a/pkg/db/v3/namespace.go
+++ b/pkg/db/v3/namespace.go
@@ -85,6 +85,8 @@ func NamespacePackageNamersForLanguage(l syftPkg.Language) map[string]NamerByPac
 		namespaces["github:npm"] = defaultPackageNamer
 	case syftPkg.Python:
 		namespaces["github:python"] = defaultPackageNamer
+	default:
+		namespaces[fmt.Sprintf("github:%s", l)] = defaultPackageNamer
 	}
 	return namespaces
 }

--- a/pkg/db/v3/namespace_test.go
+++ b/pkg/db/v3/namespace_test.go
@@ -199,12 +199,30 @@ func Test_NamespacesForLanguage(t *testing.T) {
 		expectedNamespaces []string
 		expectedNames      []string
 	}{
-		// unsupported languages
+		// default languages
 		{
 			language: syftPkg.Rust,
+			namerInput: &grypePkg.Package{
+				Name: "a-name",
+			},
+			expectedNamespaces: []string{
+				"github:rust",
+			},
+			expectedNames: []string{
+				"a-name",
+			},
 		},
 		{
 			language: syftPkg.Go,
+			namerInput: &grypePkg.Package{
+				Name: "a-name",
+			},
+			expectedNamespaces: []string{
+				"github:go",
+			},
+			expectedNames: []string{
+				"a-name",
+			},
 		},
 		// supported languages
 		{


### PR DESCRIPTION
Allow for a default guess at language namespaces, which is to try a github security advisory namespace