### PR TITLE
Include LFS in staging builds

### DIFF
--- a/.github/workflows/staging-db-publisher.yaml
+++ b/.github/workflows/staging-db-publisher.yaml
@@ -57,6 +57,13 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
+        with:
+          # this downloads and initializes LFS, but does not pull the objects
+          lfs: true
+
+      - name: Checkout LFS objects
+        # lfs pull does a lfs fetch and lfs checkout, this is NOT the same as "git pull"
+        run: git lfs pull
 
       - name: Bootstrap environment
         uses: ./.github/actions/bootstrap

--- a/publish/src/publisher/utils/grype.py
+++ b/publish/src/publisher/utils/grype.py
@@ -81,8 +81,12 @@ class Report:
             report_path = os.path.join(ERROR_DIR, "grype-error.json")
             with open(report_path, "w") as f:
                 f.write(self.report_contents)
+
+            preview = self.report_contents
+            if len(preview) > 100:
+                preview = preview[:100] + "..."
             logging.error(
-                f"json decode failed for written to: {report_path}", exc_info=exc
+                f"json decode failed, full contents written to: {report_path}\npreview: {preview}", exc_info=exc
             )
             raise
 


### PR DESCRIPTION
Without the fixtures in LFS there is no way for the publish script to run acceptance tests on the built DB (example passing run https://github.com/anchore/grype-db/actions/runs/4387332143 )