### PR TITLE
Remove use of deprecated github actions funcion "set-output"

### DIFF
--- a/.github/workflows/daily-db-publisher.yaml
+++ b/.github/workflows/daily-db-publisher.yaml
@@ -48,7 +48,7 @@ jobs:
         id: read-schema-versions
         run: |
           content=`cat grype-schema-version-mapping.json | jq -c 'keys'`
-          echo "::set-output name=schema-versions::$content"
+          echo "schema-versions=$content" >> $GITHUB_OUTPUT
 
   generate-and-publish-dbs:
     # note about workflow dispatch inputs and booleans:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
         id: read-schema-versions
         run: |
           content=`cat grype-schema-version-mapping.json | jq -c 'keys'`
-          echo "::set-output name=schema-versions::$content"
+          echo "schema-versions=$content" >> $GITHUB_OUTPUT
 
   quality-gate-acceptance-test:
     needs: read-schema-versions

--- a/.github/workflows/update-grype-release.yml
+++ b/.github/workflows/update-grype-release.yml
@@ -29,7 +29,7 @@ jobs:
           go mod tidy
 
           # export the version for use with create-pull-request
-          echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"
+          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_OUTPUT
         id: latest-version
 
       - uses: tibdex/github-app-token@v1

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -85,7 +85,7 @@ jobs:
         id: read-schema-versions
         run: |
           content=`cat grype-schema-version-mapping.json | jq -c 'keys'`
-          echo "::set-output name=schema-versions::$content"
+          echo "schema-versions=$content" >> $GITHUB_OUTPUT
 
   # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Acceptance-Test:


### PR DESCRIPTION
Use of `::set-output` in github actions is deprecated. This will effectively stop functioning on May 31st 2023. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR removes all uses of this function.