### PR TITLE
Enable daily DB publisher workflow

### DIFF
--- a/.github/workflows/daily-db-publisher.yaml
+++ b/.github/workflows/daily-db-publisher.yaml
@@ -15,9 +15,9 @@ on:
         default: true
 
   # run 4 AM (UTC) daily
-# TODO: enable for release
-#  schedule:
-#    - cron:  '0 4 * * *'
+  schedule:
+    - cron:  '0 4 * * *'
+
 env:
   CGO_ENABLED: "0"
   AWS_BUCKET: toolbox-data.anchore.io


### PR DESCRIPTION
This swaps the daily DB workflow from the old repo (grype-db-builder) to this repo.