### PR TITLE
Add list-providers command

### DIFF
--- a/.github/scripts/aggregate-all-provider-cache.py
+++ b/.github/scripts/aggregate-all-provider-cache.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-import yaml
+import json
 import sys
 import subprocess
 
-with open(".grype-db.yaml") as f:
-    providers = [x["name"] for x in yaml.safe_load(f.read()).get("provider", {}).get("configs", [])]
+output = subprocess.run("make show-providers", shell=True, check=True, stdout=subprocess.PIPE, stderr=sys.stderr).stdout
+providers = json.loads(output)
 
 print(f"providers: {providers}")
 for provider in providers:

--- a/.github/scripts/aggregate-all-provider-cache.py
+++ b/.github/scripts/aggregate-all-provider-cache.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
-import json
+import os
+import ast
 import sys
 import subprocess
 
-output = subprocess.run("make show-providers", shell=True, check=True, stdout=subprocess.PIPE, stderr=sys.stderr).stdout
-providers = json.loads(output)
+output = os.environ.get("PROVIDERS_USED", None)
+
+if not output:
+    print(f"invoking grype-db to get list of providers to use")
+    output = subprocess.run("make show-providers", shell=True, check=True, stdout=subprocess.PIPE, stderr=sys.stderr).stdout
+else:
+    print("using values from $PROVIDERS_USED environment variable")
+
+print(f"output:   {output!r}")
+
+# why in the world would we use ast instead of JSON?!
+# short answer: python borks when there are strings with single quotes instead of double quotes
+providers = ast.literal_eval(output)
 
 print(f"providers: {providers}")
+
 for provider in providers:
     subprocess.run(f"make download-provider-cache provider={provider}", shell=True, check=True, stdout=sys.stdout, stderr=sys.stderr)

--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -74,7 +74,9 @@ jobs:
   aggregate-cache:
     name: "Aggregate provider cache"
     runs-on: ubuntu-20.04
-    needs: update-provider
+    needs:
+      - update-provider
+      - discover-providers
     # set the permissions granted to the github token to read the pull cache from ghcr.io
     permissions:
       packages: write

--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -19,6 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
+        with:
+          python: false
+
+      - name: Login to ghcr.io
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io --username ${{ github.actor }} --password-stdin
+
       - name: Read configured providers
         id: read-providers
         # TODO: honor CI overrides

--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -71,15 +71,6 @@ jobs:
       - name: Upload the provider workspace state
         run: make upload-provider-cache provider=${{ matrix.provider }}
 
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: workflow,eventName
-          text: Daily Data Sync for ${{ matrix.provider }} failed
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
-
   aggregate-cache:
     name: "Aggregate provider cache"
     runs-on: ubuntu-20.04

--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -68,12 +68,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: workflow,eventName
+          text: Daily Data Sync for ${{ matrix.provider }} failed
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+
       - name: Upload the provider workspace state
+        # even if the job fails, we want to upload yesterdays cache as todays cache to continue the DB build
+        if: ${{ always() }}
         run: make upload-provider-cache provider=${{ matrix.provider }}
 
   aggregate-cache:
     name: "Aggregate provider cache"
     runs-on: ubuntu-20.04
+    if: ${{ always() }}
     needs:
       - update-provider
       - discover-providers

--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -93,17 +93,9 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io --username ${{ github.actor }} --password-stdin
 
       - name: Aggregate vulnerability data
-      # TODO: hook up to matrix override
         run: make aggregate-all-provider-cache
+        env:
+          PROVIDERS_USED: ${{ needs.discover-providers.outputs.providers }}
 
       - name: Upload vulnerability data cache image
         run: make upload-all-provider-cache
-
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: workflow,eventName
-          text: Daily Data Sync aggregation failed
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TEMP_DIR = ./.tmp
 RESULTS_DIR = $(TEMP_DIR)/results
 
 DB_ARCHIVE = ./grype-db-cache.tar.gz
-GRYPE_DB = go run ./cmd/$(BIN)/main.go
+GRYPE_DB = go run ./cmd/$(BIN)/main.go -c publish/.grype-db.yaml
 GRYPE_DB_DATA_IMAGE_NAME = ghcr.io/anchore/$(BIN)/data
 date = $(shell date -u +"%y-%m-%d")
 
@@ -197,7 +197,7 @@ update-test-fixtures:
 .PHONY: show-providers
 show-providers:
 	@# this is used in CI to generate a job matrix, pulling data for each provider concurrently
-	@go run ./cmd/grype-db list-providers -c publish/.grype-db.yaml -q -o json
+	@$(GRYPE_DB) list-providers -q -o json
 
 .PHONY: download-provider-cache
 download-provider-cache:

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ update-test-fixtures:
 .PHONY: show-providers
 show-providers:
 	@# this is used in CI to generate a job matrix, pulling data for each provider concurrently
-	@cat .grype-db.yaml | python -c 'import yaml; import json; import sys; print(json.dumps([x["name"] for x in yaml.safe_load(sys.stdin).get("provider",{}).get("configs",[])]));'
+	@go run ./cmd/grype-db list-providers -c publish/.grype-db.yaml -q -o json
 
 .PHONY: download-provider-cache
 download-provider-cache:

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ upload-provider-cache: ci-check
 	$(call title,Uploading "$(provider)" existing provider data cache)
 
 	@rm -f $(DB_ARCHIVE)
+	$(GRYPE_DB) cache status -p $(provider)
 	$(GRYPE_DB) cache backup -v --path $(DB_ARCHIVE) -p $(provider)
 	oras push -v $(GRYPE_DB_DATA_IMAGE_NAME)/$(provider):$(date) $(DB_ARCHIVE) --annotation org.opencontainers.image.source=$(SOURCE_REPO_URL)
 	$(TEMP_DIR)/crane tag $(GRYPE_DB_DATA_IMAGE_NAME)/$(provider):$(date) latest
@@ -228,6 +229,7 @@ upload-all-provider-cache: ci-check
 	$(call title,Uploading existing provider data cache)
 
 	@rm -f $(DB_ARCHIVE)
+	$(GRYPE_DB) cache status
 	$(GRYPE_DB) cache backup -v --path $(DB_ARCHIVE)
 	oras push -v $(GRYPE_DB_DATA_IMAGE_NAME):$(date) $(DB_ARCHIVE) --annotation org.opencontainers.image.source=$(SOURCE_REPO_URL)
 	$(TEMP_DIR)/crane tag $(GRYPE_DB_DATA_IMAGE_NAME):$(date) latest

--- a/cmd/grype-db/cli/cli.go
+++ b/cmd/grype-db/cli/cli.go
@@ -40,6 +40,7 @@ func New(opts ...Option) *cobra.Command {
 	root.AddCommand(commands.Pull(app))
 	root.AddCommand(commands.Build(app))
 	root.AddCommand(commands.Package(app))
+	root.AddCommand(commands.ListProviders(app))
 	root.AddCommand(cache)
 
 	return root

--- a/cmd/grype-db/cli/commands/list_providers.go
+++ b/cmd/grype-db/cli/commands/list_providers.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/scylladb/go-set/strset"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/anchore/grype-db/cmd/grype-db/application"
+	"github.com/anchore/grype-db/cmd/grype-db/cli/options"
+	"github.com/anchore/grype-db/internal/log"
+	"github.com/anchore/grype-db/pkg/provider/providers"
+	"github.com/anchore/grype-db/pkg/provider/providers/vunnel"
+)
+
+var _ options.Interface = &listProvidersConfig{}
+
+type listProvidersConfig struct {
+	options.Format   `yaml:",inline" mapstructure:",squash"`
+	options.Provider `yaml:"provider" json:"provider" mapstructure:"provider"`
+}
+
+func (o *listProvidersConfig) AddFlags(flags *pflag.FlagSet) {
+	options.AddAllFlags(flags, &o.Format, &o.Provider)
+}
+
+func (o *listProvidersConfig) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
+	return options.BindAllFlags(flags, v, &o.Format, &o.Provider)
+}
+
+func ListProviders(app *application.Application) *cobra.Command {
+	cfg := listProvidersConfig{
+		Provider: options.DefaultProvider(),
+		Format: options.Format{
+			Output:           "text",
+			AllowableFormats: []string{"text", "json"},
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list-providers",
+		Short: "list all configured providers",
+		Args: chainArgs(
+			cobra.NoArgs,
+			func(cmd *cobra.Command, args []string) error {
+				allowableOutputs := strset.New(cfg.Format.AllowableFormats...)
+				if !allowableOutputs.Has(cfg.Format.Output) {
+					return fmt.Errorf("invalid output format: %s (allowable: %s)", cfg.Format.Output, strings.Join(cfg.Format.AllowableFormats, ", "))
+				}
+				return nil
+			},
+		),
+		PreRunE: app.Setup(&cfg),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return app.Run(cmd.Context(), async(func() error {
+				return runListProviders(cfg)
+			}))
+		},
+	}
+
+	commonConfiguration(app, cmd, &cfg)
+
+	return cmd
+}
+
+func runListProviders(cfg listProvidersConfig) error {
+	ps, err := providers.New(cfg.Root, vunnel.Config{
+		Executor:         cfg.Vunnel.Executor,
+		DockerTag:        cfg.Vunnel.DockerTag,
+		DockerImage:      cfg.Vunnel.DockerImage,
+		GenerateConfigs:  cfg.Vunnel.GenerateConfigs,
+		ExcludeProviders: cfg.Vunnel.ExcludeProviders,
+		Env:              cfg.Vunnel.Env,
+	}, cfg.Provider.Configs...)
+	if err != nil {
+		if errors.Is(err, providers.ErrNoProviders) {
+			log.Error("configure a provider via the application config or use -g to generate a list of configs from vunnel")
+		}
+		return err
+	}
+
+	if cfg.Format.Output == "text" {
+		for _, p := range ps {
+			fmt.Println(p.ID().Name)
+		}
+	} else if cfg.Format.Output == "json" {
+		names := make([]string, 0, len(ps))
+		for _, p := range ps {
+			names = append(names, p.ID().Name)
+		}
+		by, err := json.Marshal(names)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(by))
+	}
+
+	return nil
+}

--- a/cmd/grype-db/cli/commands/utils.go
+++ b/cmd/grype-db/cli/commands/utils.go
@@ -37,28 +37,39 @@ func commonConfiguration(app *application.Application, cmd *cobra.Command, opts 
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 	cmd.SetHelpTemplate(`{{if (or .Long .Short)}}{{.Long}}{{if not .Long}}{{.Short}}{{end}}
-	
-	{{end}}Usage:{{if .Runnable}}
-	{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-	{{.CommandPath}} [command]{{end}}{{if .HasExample}}
-	
-	{{.Example}}{{end}}{{if gt (len .Aliases) 0}}
-	
-	Aliases:
-	{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}
-	
-	Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-	{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-	
-	{{if not .CommandPath}}Global {{end}}Flags:
-	{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if (and .HasAvailableInheritedFlags (not .CommandPath))}}
-	
-	Global Flags:
-	{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-	
-	Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-	{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-	
-	Use "{{if .CommandPath}}{{.CommandPath}} {{end}}[command] --help" for more information about a command.{{end}}
-	`)
+
+{{end}}Usage:{{if .Runnable}}
+{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+{{.CommandPath}} [command]{{end}}{{if .HasExample}}
+
+{{.Example}}{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+{{if not .CommandPath}}Global {{end}}Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if (and .HasAvailableInheritedFlags (not .CommandPath))}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{if .CommandPath}}{{.CommandPath}} {{end}}[command] --help" for more information about a command.{{end}}
+`)
+}
+
+func chainArgs(processors ...func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		for _, p := range processors {
+			if err := p(cmd, args); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 }

--- a/cmd/grype-db/cli/options/format.go
+++ b/cmd/grype-db/cli/options/format.go
@@ -1,0 +1,30 @@
+package options
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+var _ Interface = &Format{}
+
+type Format struct {
+	Output           string   `yaml:"output" json:"output" mapstructure:"output"`
+	AllowableFormats []string `yaml:"-" json:"-" mapstructure:"-"`
+}
+
+func (o *Format) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVarP(
+		&o.Output,
+		"output", "o", o.Output,
+		fmt.Sprintf("output format to report results in (allowable values: %s)", o.AllowableFormats),
+	)
+}
+
+func (o *Format) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
+	if err := Bind(v, "output", flags.Lookup("output")); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/provider/providers/vunnel/provider.go
+++ b/pkg/provider/providers/vunnel/provider.go
@@ -146,8 +146,15 @@ func GenerateConfigs(root string, cfg Config) ([]provider.Config, error) {
 		return nil, err
 	}
 	cmd, args := cmdList[0], cmdList[1:]
-	out, err := exec.Command(cmd, args...).Output()
+
+	cmdObj := exec.Command(cmd, args...)
+	sb := strings.Builder{}
+	cmdObj.Stderr = &sb
+	out, err := cmdObj.Output()
 	if err != nil {
+		if sb.Len() > 0 {
+			log.Errorf("vunnel list failed: %s", sb.String())
+		}
 		return nil, fmt.Errorf("unable to execute vunnel list: %w", err)
 	}
 


### PR DESCRIPTION
Since the provider config generation from vunnel has been added, this ports over the daily data sync workflow to deriving the provider matrix from grype-db output (which runs vunnel internally), not a static grype-db config.

Additionally this PR:
- removes a very noisy slack notification in leu of a notification at the end of the data sync workflow
- fixes the makefile to always reference the publish config when running grype-db
- updates the aggregation script to use the make target
- allows for the daily db sync to continue on failure, using the previous day's cache for today's cache