### PR TITLE
Add vunnel config path to app config

### DIFF
--- a/cmd/grype-db/cli/commands/build.go
+++ b/cmd/grype-db/cli/commands/build.go
@@ -66,6 +66,7 @@ func runBuild(cfg buildConfig) error {
 	}
 
 	pvdrs, err := providers.New(cfg.Provider.Root, vunnel.Config{
+		Config:           cfg.Vunnel.Config,
 		Executor:         cfg.Vunnel.Executor,
 		DockerTag:        cfg.Vunnel.DockerTag,
 		DockerImage:      cfg.Vunnel.DockerImage,

--- a/cmd/grype-db/cli/commands/pull.go
+++ b/cmd/grype-db/cli/commands/pull.go
@@ -56,6 +56,7 @@ func Pull(app *application.Application) *cobra.Command {
 
 func runPull(cfg pullConfig) error {
 	ps, err := providers.New(cfg.Root, vunnel.Config{
+		Config:           cfg.Vunnel.Config,
 		Executor:         cfg.Vunnel.Executor,
 		DockerTag:        cfg.Vunnel.DockerTag,
 		DockerImage:      cfg.Vunnel.DockerImage,

--- a/cmd/grype-db/cli/options/vunnel.go
+++ b/cmd/grype-db/cli/options/vunnel.go
@@ -14,6 +14,7 @@ type Vunnel struct {
 	// (none)
 
 	// unbound options
+	Config           string            `yaml:"config" json:"config" mapstructure:"config"`
 	Executor         string            `yaml:"executor" json:"executor" mapstructure:"executor"`
 	DockerTag        string            `yaml:"docker-tag" json:"docker-tag" mapstructure:"docker-tag"`
 	DockerImage      string            `yaml:"docker-image" json:"docker-image" mapstructure:"docker-image"`
@@ -59,6 +60,7 @@ func (o *Vunnel) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
 	}
 
 	// set default values for non-bound struct items
+	v.SetDefault("vunnel.config", o.Config)
 	v.SetDefault("vunnel.executor", o.Executor)
 	v.SetDefault("vunnel.docker-tag", o.DockerTag)
 	v.SetDefault("vunnel.docker-image", o.DockerImage)


### PR DESCRIPTION
Today the `provider.vunnel.config` option is not exposed, this PR corrects this.