### PR TITLE
Validations must use PR events

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -1,7 +1,7 @@
 name: "Validations"
 on:
   workflow_dispatch:
-  push:
+  pull_request:
 
 env:
   CGO_ENABLED: "0"


### PR DESCRIPTION
Otherwise we would not be able to accept PRs from forks