### PR TITLE
fix: surface vunnel logs with provider log level if possible

### DIFF
--- a/pkg/provider/providers/external/log_writer.go
+++ b/pkg/provider/providers/external/log_writer.go
@@ -2,9 +2,18 @@ package external
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/anchore/grype-db/internal/log"
+)
+
+var (
+	logLevelPattern = regexp.MustCompile(`^(?P<prefix>.*)\[(?P<level>TRACE|DEBUG|INFO|WARN|WARNING|ERROR)\s?\] (?P<suffix>.*)$`)
+
+	// The provider logging level can be independently controlled via vunnel config,
+	// so the default if no log level could be parsed should be info
+	defaultLogLevel = "INFO"
 )
 
 type logWriter struct {
@@ -17,11 +26,91 @@ func newLogWriter(name string) *logWriter {
 	}
 }
 
+// MatchNamedCaptureGroups takes a regular expression and string and returns all of the named capture group results in a map.
+// This is only for the first match in the regex. Callers shouldn't be providing regexes with multiple capture groups with the same name.
+func matchNamedCaptureGroups(regEx *regexp.Regexp, content string) map[string]string {
+	// note: we are looking across all matches and stopping on the first non-empty match. Why? Take the following example:
+	// input: "cool something to match against" pattern: `((?P<name>match) (?P<version>against))?`. Since the pattern is
+	// encapsulated in an optional capture group, there will be results for each character, but the results will match
+	// on nothing. The only "true" match will be at the end ("match against").
+	allMatches := regEx.FindAllStringSubmatch(content, -1)
+	var results map[string]string
+	for _, match := range allMatches {
+		// fill a candidate results map with named capture group results, accepting empty values, but not groups with
+		// no names
+		for nameIdx, name := range regEx.SubexpNames() {
+			if nameIdx > len(match) || len(name) == 0 {
+				continue
+			}
+			if results == nil {
+				results = make(map[string]string)
+			}
+			results[name] = match[nameIdx]
+		}
+		// note: since we are looking for the first best potential match we should stop when we find the first one
+		// with non-empty results.
+		if !isEmptyMap(results) {
+			break
+		}
+	}
+	return results
+}
+
+func isEmptyMap(m map[string]string) bool {
+	if len(m) == 0 {
+		return true
+	}
+	for _, value := range m {
+		if value != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func processLogLine(line string) (string, string) {
+	line = strings.TrimRight(line, "\n")
+	groups := matchNamedCaptureGroups(logLevelPattern, line)
+
+	level, ok := groups["level"]
+	if !ok || level == "" {
+		return defaultLogLevel, line
+	}
+
+	prefix, ok := groups["prefix"]
+	if !ok {
+		return defaultLogLevel, line
+	}
+
+	suffix, ok := groups["suffix"]
+	if !ok {
+		return defaultLogLevel, line
+	}
+
+	message := fmt.Sprintf("%s%s", prefix, suffix)
+	return strings.ToUpper(level), message
+}
+
 func (lw logWriter) Write(p []byte) (n int, err error) {
 	for _, line := range strings.Split(string(p), "\n") {
-		line = strings.TrimRight(line, "\n")
+		level, line := processLogLine(line)
 		if line != "" {
-			log.Debug(fmt.Sprintf("[%s]", lw.name) + line)
+			message := fmt.Sprintf("[%s]", lw.name) + line
+
+			switch level {
+			case "TRACE":
+				log.Trace(message)
+			case "DEBUG":
+				log.Debug(message)
+			case "INFO":
+				log.Info(message)
+			case "WARN", "WARNING":
+				log.Warn(message)
+			case "ERROR":
+				log.Error(message)
+			default:
+				log.Info(message)
+			}
 		}
 	}
 

--- a/pkg/provider/providers/external/log_writer_test.go
+++ b/pkg/provider/providers/external/log_writer_test.go
@@ -1,0 +1,67 @@
+package external
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogWriter_processLogLine(t *testing.T) {
+	tests := []struct {
+		name            string
+		line            string
+		expectedLevel   string
+		expectedMessage string
+	}{
+		{
+			name:            "default log level",
+			line:            `\033[0maggregating vulnerability data providers=[rhel]`,
+			expectedLevel:   defaultLogLevel,
+			expectedMessage: `\033[0maggregating vulnerability data providers=[rhel]`,
+		},
+		{
+			name:            "info log level",
+			line:            `\033[0m[INFO ] aggregating vulnerability data providers=[rhel]`,
+			expectedLevel:   "INFO",
+			expectedMessage: `\033[0maggregating vulnerability data providers=[rhel]`,
+		},
+		{
+			name:            "warning log level",
+			line:            `blah [WARNING] something could be going wrong`,
+			expectedLevel:   "WARNING",
+			expectedMessage: `blah something could be going wrong`,
+		},
+		{
+			name:            "warn log level",
+			line:            `blah [WARN ] something could be going wrong`,
+			expectedLevel:   "WARN",
+			expectedMessage: `blah something could be going wrong`,
+		},
+		{
+			name:            "debug log level",
+			line:            `abcdefg [DEBUG] jasdklfjlaksdjflksadj`,
+			expectedLevel:   "DEBUG",
+			expectedMessage: `abcdefg jasdklfjlaksdjflksadj`,
+		},
+		{
+			name:            "trace log level",
+			line:            `[TRACE] -----^^^^^`,
+			expectedLevel:   "TRACE",
+			expectedMessage: `-----^^^^^`,
+		},
+		{
+			name:            "error log level",
+			line:            `[ERROR] something bad happened`,
+			expectedLevel:   "ERROR",
+			expectedMessage: `something bad happened`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			level, message := processLogLine(test.line)
+			assert.Equal(t, level, test.expectedLevel)
+			assert.Equal(t, message, test.expectedMessage)
+		})
+	}
+}


### PR DESCRIPTION
Currently there won't be any logging surfaced from vunnel providers when grype-db isn't set to debug because all vunnel logs are being logged from go at the debug level.  Since the vunnel log level is configurable separately, this changes the default go log level output from vunnel to be Info and additionally attempts to parse the actual log level from the vunnel calls and log at the corresponding level from go.