### PR TITLE
Swap compression method to zstd

### DIFF
--- a/cmd/grype-db/cli/commands/package.go
+++ b/cmd/grype-db/cli/commands/package.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"fmt"
+
+	"github.com/scylladb/go-set/strset"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -37,6 +40,12 @@ func Package(app *application.Application) *cobra.Command {
 		Args:    cobra.NoArgs,
 		PreRunE: app.Setup(&cfg),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cfg.OverrideArchiveExtension != "" {
+				if !strset.New("tar.gz", "tar.zst").Has(cfg.OverrideArchiveExtension) {
+					return fmt.Errorf("archive-extension must be 'tar.gz' or 'tar.zst'")
+				}
+			}
+
 			return app.Run(cmd.Context(), async(func() error {
 				return runPackage(cfg)
 			}))
@@ -49,5 +58,5 @@ func Package(app *application.Application) *cobra.Command {
 }
 
 func runPackage(cfg packageConfig) error {
-	return process.Package(cfg.DBLocation.Directory, cfg.PublishBaseURL)
+	return process.Package(cfg.DBLocation.Directory, cfg.PublishBaseURL, cfg.OverrideArchiveExtension)
 }

--- a/cmd/grype-db/cli/options/package.go
+++ b/cmd/grype-db/cli/options/package.go
@@ -9,7 +9,8 @@ var _ Interface = &Package{}
 
 type Package struct {
 	// bound options
-	PublishBaseURL string `yaml:"publish-base-url" json:"publish-base-url" mapstructure:"publish-base-url"`
+	PublishBaseURL           string `yaml:"publish-base-url" json:"publish-base-url" mapstructure:"publish-base-url"`
+	OverrideArchiveExtension string `yaml:"override-archive-extension" json:"override-archive-extension" mapstructure:"override-archive-extension"`
 
 	// unbound options
 	// (none)
@@ -27,11 +28,21 @@ func (o *Package) AddFlags(flags *pflag.FlagSet) {
 		"publish-base-url", "u", o.PublishBaseURL,
 		"the base URL used for reference in the listing.json index file",
 	)
+
+	flags.StringVarP(
+		&o.OverrideArchiveExtension,
+		"archive-extension", "e",
+		o.OverrideArchiveExtension,
+		"Override the extension used during DB archiving (default is 'tar.gz' or 'tar.zst' based on the grype DB schema)")
 }
 
 func (o *Package) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
 	// set default values for bound struct items
 	if err := Bind(v, "package.publish-base-url", flags.Lookup("publish-base-url")); err != nil {
+		return err
+	}
+
+	if err := viper.BindPFlag("package.override-archive-extension", flags.Lookup("archive-extension")); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jinzhu/copier v0.3.5
+	github.com/klauspost/compress v1.16.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/profile v1.7.0
@@ -110,7 +111,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/klauspost/compress v1.16.4 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f // indirect
 	github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d // indirect

--- a/publish/src/publisher/console.py
+++ b/publish/src/publisher/console.py
@@ -19,8 +19,6 @@ import publisher.utils.s3utils as s3utils
 from publisher.utils.constants import (
     DB_DIR,
     DB_SUFFIXES,
-    LEGACY_DB_SUFFIXES,
-    NEW_DB_SUFFIXES,
     GOLDEN_REPORT_LOCATION,
     TEST_IMAGE,
     STAGE_DIR,
@@ -125,7 +123,7 @@ def upload_listing(s3_bucket: str, s3_path: str, dry_run: bool):
 
     # look for existing DBs in S3
     existing_paths_by_basename = existing_dbs_in_s3(
-        s3_bucket=s3_bucket, s3_path=s3_path, suffixes=LEGACY_DB_SUFFIXES,
+        s3_bucket=s3_bucket, s3_path=s3_path, suffixes=DB_SUFFIXES,
     )
 
     # determine what basenames are new relative to the listing file and the current S3 state
@@ -147,7 +145,7 @@ def upload_listing(s3_bucket: str, s3_path: str, dry_run: bool):
             paths_by_basename=existing_paths_by_basename,
             s3_bucket=s3_bucket,
             s3_path=s3_path,
-            suffixes=LEGACY_DB_SUFFIXES,
+            suffixes=DB_SUFFIXES,
             max_age=MAX_DB_AGE,
     ):
         the_listing.add(entry)

--- a/publish/src/publisher/utils/constants.py
+++ b/publish/src/publisher/utils/constants.py
@@ -16,9 +16,8 @@ GRYPE_DB_CONFIG = os.path.join(root, "publish", ".grype-db.yaml")
 
 # BUCKET = os.environ["AWS_BUCKET"]         # e.g. "toolbox-data.anchore.io"
 # DBS_PATH = os.environ["AWS_BUCKET_PATH"]  # e.g. "grype/databases"
-LEGACY_DB_SUFFIXES = {".tar.gz"}
-NEW_DB_SUFFIXES = {".tar.zst"}
-DB_SUFFIXES = {*LEGACY_DB_SUFFIXES, *NEW_DB_SUFFIXES}
+
+DB_SUFFIXES = {".tar.gz", ".tar.zst"}
 GOLDEN_REPORT_LOCATION = os.path.join(root, "publish", "test-fixtures")
 
 

--- a/publish/src/publisher/utils/listing.py
+++ b/publish/src/publisher/utils/listing.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from publisher.utils.constants import (
     DB_SUFFIXES,
-    LEGACY_DB_SUFFIXES,
 )
 
 import iso8601  # type: ignore

--- a/publish/tests/utils/test_listing.py
+++ b/publish/tests/utils/test_listing.py
@@ -4,9 +4,6 @@ import json
 import pytest
 
 from publisher.utils import listing
-from publisher.utils.constants import (
-    LEGACY_DB_SUFFIXES,
-)
 
 
 def test_listing_add_sorts_by_date():


### PR DESCRIPTION
Prototype for switching the distributed archives to `tar.zst` (over `tar.gz`) for better compression ratio without sacrificing decompression time (compressing one archive now takes ~3.5 minutes instead of ~15 seconds), compression time is essentially irrelevant (worth sacrificing) since this is run nightly.

| Method | Compression Ratio | Compression Time | Decompression Time (with grype) |
| --- | --- | --- | --- |
| gzip (today) | 6.83 | 15 seconds* | 3.8 seconds* |
| xz (-6) | 11.67* | 3.5 minutes | 30 seconds |
| zstd (-19) | 10.9 |  1.5 minutes | 4 seconds |


_* = best_

zstd appears to make the best trade offs for our use case (better compression ratio without sacrificing decompression time).

More background: https://linuxreviews.org/Comparison_of_Compression_Algorithms

Owed before merging:
- [x] release to staging (https://github.com/anchore/grype-db/actions/runs/4852164239)

<img width="785" alt="Screenshot 2023-05-01 at 3 13 46 PM" src="https://user-images.githubusercontent.com/590471/235513660-31bf14bf-23dd-4f85-a981-28a27f7704b4.png">
<img width="984" alt="Screenshot 2023-05-01 at 3 16 59 PM" src="https://user-images.githubusercontent.com/590471/235514173-3bd7be74-8402-4efd-bc42-7b4a55887a28.png">


67 MB (this PR) < 119 MB (today) 🎉 
