### PR TITLE
Revert zstd as a default compression method

### DIFF
--- a/pkg/process/package.go
+++ b/pkg/process/package.go
@@ -46,13 +46,17 @@ func Package(dbDir, publishBaseURL, overrideArchiveExtension string) error {
 		return fmt.Errorf("unable to create random archive trailer: %w", err)
 	}
 
-	// default to zstandard, which can be used on v4 schema and above (see github.com/anchore/grype-db-builder/pull/176)
-	var extension = "tar.zst"
+	// TODO (alex): supporting tar.zst
+	// var extension = "tar.zst"
+	var extension = "tar.gz"
+
 	if overrideArchiveExtension != "" {
 		extension = strings.TrimLeft(overrideArchiveExtension, ".")
-	} else if metadata.Version < 5 {
-		extension = "tar.gz"
 	}
+	// TODO (alex): supporting tar.zst
+	// else if metadata.Version < 5 {
+	// 	extension = "tar.gz"
+	// }
 
 	var found bool
 	for _, valid := range []string{"tar.zst", "tar.gz"} {


### PR DESCRIPTION
Follow up to #98 , we won't be able to pull the trigger on using zstd until all downstream users of this data pipeline are accounted for. For the meantime I'll leave the method in place with all validators so that all that would be needed is to revert this PR. This means that anyone who wishes to build tar.zst archives for their version of grype can still do so with this PR.

Needed before merging:
- [x] passing publish pipeline to staging (https://github.com/anchore/grype-db/actions/runs/4865126111)