### PR TITLE
chore: regenerate the test fixtures to account for ubuntu data updates

### DIFF
--- a/publish/test-fixtures/centos-8.2.2004.json
+++ b/publish/test-fixtures/centos-8.2.2004.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6924cb15cb5e9065217a0a0568f78f488ea9042f1fd8bd56e6d28775c76f2e4a
-size 2520519
+oid sha256:1a463a35a9e5f3660d9ddb3fc69479ef70aac3afb9cd175271165d85b0c22c58
+size 2868899

--- a/test/acceptance/test-fixtures/result/sets/acceptance-test.json
+++ b/test/acceptance/test-fixtures/result/sets/acceptance-test.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43d91ca5f80221b16a43dbc751cc2aaca6e54a634997dda57d4a0c0d7f307365
-size 110827
+oid sha256:12da5a970047aa3bc4d2ab3409d735fefdde62bf307b9576a05f336d0a13006a
+size 105222

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.12.1/2023-03-09T17:34:42+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.12.1/2023-03-09T17:34:42+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17c9a893ab6447b0f9fc15900a85df82e6462caa62ec942d01dba56b4db7c118
-size 55343

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.12.1/2023-03-09T17:34:42+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.12.1/2023-03-09T17:34:42+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ef180de32257be2587cf86cf2248983ae725e2f538ff5e8b3bc9a45339eefef
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.12.1/2023-06-29T21:33:22.221818+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.12.1/2023-06-29T21:33:22.221818+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:670ae8870a43ad5743b03a6b7483803e272031646eda9d90945aeceaa9d96033
+size 70903

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.12.1/2023-06-29T21:33:22.221818+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.12.1/2023-06-29T21:33:22.221818+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:317d7ac91f141b51037958f46f90c36485e21d578d4bec48ed21588fd1d6fd7d
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.40.1/2023-03-09T17:36:39+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.40.1/2023-03-09T17:36:39+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2799fd3c8ac7d2df0a7f45a1a997e9daba259d80997e59f2d6780febc20e6bce
-size 129989

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.40.1/2023-03-09T17:36:39+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.40.1/2023-03-09T17:36:39+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0a366ae766139575f8d10c37dd5ef3bf257cba93d9b004c8a6bbc5937e51879
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.40.1/2023-06-29T21:35:02.303565+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.40.1/2023-06-29T21:35:02.303565+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2ed8d45f40615c5a765ac920f82b9d762f86be976bd7cbc22c3c932f584960e
+size 156905

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.40.1/2023-06-29T21:35:02.303565+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.40.1/2023-06-29T21:35:02.303565+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac15df7480828aebf6e3ec8db01ed49b5fa4e2776d432374144b5edd2ac96cdb
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.50.2/2023-03-09T17:38:57+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.50.2/2023-03-09T17:38:57+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:149d6ae8f91f08a4b08ce7c4c637da7b04565a1c9f98577fb7e251943f89b3f5
-size 130979

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.50.2/2023-03-09T17:38:57+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.50.2/2023-03-09T17:38:57+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f07bee70547978467c9d05a9d57e48bd0a804e6b0c8f4fb795d79c8df78e3688
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.50.2/2023-06-29T21:37:02.321580+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.50.2/2023-06-29T21:37:02.321580+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:150e7fb3e2b4f583a26cd2f40ae401a46bcee46409e41fdb980801779618ae73
+size 157959

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.50.2/2023-06-29T21:37:02.321580+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.50.2/2023-06-29T21:37:02.321580+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:918eb07f94208403f4a6ce009a3bcac9f9586ee9d7a6290e36d52e88a2fd49ab
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:32+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:32+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:253305f4b4809e603a10f0db2ad42ae33cfd9f20293807b66a0e9b70c816183a
-size 178962

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:32+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:32+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67466851583cceb6cf3de68ac884b40fc8ce39825d88c09409ad775f2b7372f4
-size 967

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:03.478264+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:03.478264+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf4cd70e527f013cd61dad05380234a93902ccdbf7ae4ff8e8054e6ce624b265
+size 219809

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:03.478264+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:03.478264+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4cb2a1b9910caaedb457d43e285416897d9794c57a94be9337c2b5714ebcc3d
+size 892

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.7.0/2023-03-09T17:31:43+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.7.0/2023-03-09T17:31:43+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f9d3a75edf6bdfc6cbb28f7bb8b5c620554f851cb0f1677e28d9fdc930f150b
-size 34061

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.7.0/2023-03-09T17:31:43+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.7.0/2023-03-09T17:31:43+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:057983ffeaa0cbadf6b91a94acdbc1baa93860dec0e37a2f54e89fc75bcd64a2
-size 626

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.7.0/2023-06-29T21:27:31.157286+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.7.0/2023-06-29T21:27:31.157286+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32abe98f6265e2bb48f0792c0b6b6b9aad41dda03dcd5f9a959d90d20b8fe034
+size 34337

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.7.0/2023-06-29T21:27:31.157286+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:01c78cee3fe398bf1f77566177770b07f1d2af01753c2434cb0735bd43a078b6/grype@v0.7.0/2023-06-29T21:27:31.157286+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d20900c3556fa3cdb0a76c3e9a0b181ddd89d3fea86088ddb4ffef72b66d69a6
+size 551

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.12.1/2023-03-09T17:35:21+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.12.1/2023-03-09T17:35:21+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aac7158f6a18fb80b90fa1914c6b4e24e2ac77b2edb675eb484623cb5f8ec7f2
-size 62933

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.12.1/2023-03-09T17:35:21+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.12.1/2023-03-09T17:35:21+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:251fedb81875c617383f9e1a5622aaafaeff602b70104716d4e1f14f4b9ffbc1
-size 889

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.12.1/2023-06-29T21:33:55.627170+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.12.1/2023-06-29T21:33:55.627170+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:154821f7d651bbc68c420bfb465bf88277a6831c3367af824539482e237f6bfe
+size 318714

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.12.1/2023-06-29T21:33:55.627170+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.12.1/2023-06-29T21:33:55.627170+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4606b5ba6056c4b0e5210cf3f8e155a048e8d5287cf536d7ba8fd7f6ec4e1405
+size 814

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.40.1/2023-03-09T17:37:24+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.40.1/2023-03-09T17:37:24+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5485a461996b191a48c423e5905c4103482249a415981db6f418c283d68ea8a1
-size 151193

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.40.1/2023-03-09T17:37:24+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.40.1/2023-03-09T17:37:24+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f1a28a3f860447b190c2a0824052258b85b5990d3f33211429c823b6e81e8c8
-size 889

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.40.1/2023-06-29T21:35:42.870314+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.40.1/2023-06-29T21:35:42.870314+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e913607c5d79dadc464cdbaf6a5d6569b86b89b5062a15728ae44d2ddd44a037
+size 711178

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.40.1/2023-06-29T21:35:42.870314+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.40.1/2023-06-29T21:35:42.870314+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5243634c7b5ce2c4100910773e54d7349e2a0dda0eb3b45cfd61f4e1e0d05b3e
+size 814

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.50.2/2023-03-09T17:39:44+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.50.2/2023-03-09T17:39:44+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6262620dd4e00ab397a30b7bfeeaeb7bca523495c449e91273b29fbcc65a81cc
-size 152527

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.50.2/2023-03-09T17:39:44+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.50.2/2023-03-09T17:39:44+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c19f6eb1a9bd9f985b455f74a2a91969ca3d903b4b9fc29cf0a6a96aa0bbd70c
-size 889

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.50.2/2023-06-29T21:37:44.782239+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.50.2/2023-06-29T21:37:44.782239+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:713b39a49330f6dacb8039747513af37b9a4ebdc11e1794cb24b620b7640cf90
+size 717888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.50.2/2023-06-29T21:37:44.782239+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.50.2/2023-06-29T21:37:44.782239+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e204923261cf7e17764dd7c8a739439288e2f7806cc9bf849b48de716eae63a7
+size 814

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:15+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:15+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d63acce47042ceb29547e3eefbbccd98a547a6bed4366d1f28018c12d068dd7
-size 153860

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:15+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:15+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7935d56abc165d199b6fdb42f26349ffb846840e51c7cf16f2d0f494618a1050
-size 968

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:40.939883+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:40.939883+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:119e7f3d4adb233917a403f4ce006740ddbe4ff70ff119ed1458d4ef4f0d096e
+size 726407

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:40.939883+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:40.939883+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7a0724b659d3fad63750552c73c4417ca83f3a41b119640db733408b4c9b1a5
+size 893

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.7.0/2023-03-09T17:32:57+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.7.0/2023-03-09T17:32:57+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c29280d841493be75da49ebc8a13474779732ab86782fb77fc99fc25954d46af
-size 64477

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.7.0/2023-03-09T17:32:57+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.7.0/2023-03-09T17:32:57+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce6ccb7cdbfcfd16a7240138de910c7e418863d5f3b596d886f0562d28f584d2
-size 627

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.7.0/2023-06-29T21:29:57.342417+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.7.0/2023-06-29T21:29:57.342417+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc61592842e63d763c2228d78d7db311e257ee39b89b88a342ed0143b592313b
+size 350536

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.7.0/2023-06-29T21:29:57.342417+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:05a70ba6d55e6d59b06ce8329bdd9540813e3d155ee7f41fe6044117caf81991/grype@v0.7.0/2023-06-29T21:29:57.342417+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49253b8cdec3d0dbfaf0987bedd9f15ef3e44abb7731b20d2d3347da966cf68a
+size 552

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.12.1/2023-03-09T17:35:08+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.12.1/2023-03-09T17:35:08+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb001c0344d63850e4f4b700d8ec2cfea313d03beb3b4e645fce71a62e3961c3
-size 96189

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.12.1/2023-03-09T17:35:08+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.12.1/2023-03-09T17:35:08+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9285f93688ee348c1ef960b6273b99e1d3d5683165288e82ba4052022f0d1abf
-size 886

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.12.1/2023-06-29T21:33:44.773313+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.12.1/2023-06-29T21:33:44.773313+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f67656c4cd178e51f9ed7f9aa81039fdd17af5c02bef9b64d4c0e9b1a366f36
+size 103684

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.12.1/2023-06-29T21:33:44.773313+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.12.1/2023-06-29T21:33:44.773313+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be8707f66e4d31606053e3515df42daf6f9ad8285ec4244ba57e7f017dacd4fa
+size 811

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.40.1/2023-03-09T17:37:08+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.40.1/2023-03-09T17:37:08+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82b738f9f336520e66c615ab00c2792fe6dfbd16f450e5d9da849af0dd6d0d2a
-size 103714

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.40.1/2023-03-09T17:37:08+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.40.1/2023-03-09T17:37:08+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cad074f91acdbbf4859d2067605cc85bd9c4e196d0586bf1b813e4713d6bc93c
-size 886

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.40.1/2023-06-29T21:35:28.548870+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.40.1/2023-06-29T21:35:28.548870+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3fab0dd9b6dfcb4a24858600abbf293384628905b5b75bde44745485d524b0a
+size 116314

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.40.1/2023-06-29T21:35:28.548870+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.40.1/2023-06-29T21:35:28.548870+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e67823fa7fb328fb965656b7ad60bf920667d1609cd0eb675d0e1a49dd8ad12d
+size 811

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.50.2/2023-03-09T17:39:27+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.50.2/2023-03-09T17:39:27+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b6889bef20faa4fafeba347b1e6e91c2c1cfa88ab68b76f3ae712c9bea40d02
-size 93955

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.50.2/2023-03-09T17:39:27+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.50.2/2023-03-09T17:39:27+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba8bb2654fc305d54e384bac917b6c6ba2c527def52af8778ecc6a92e81c8772
-size 886

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.50.2/2023-06-29T21:37:30.061824+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.50.2/2023-06-29T21:37:30.061824+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:359630762d252686bd0fbea20a028ac6c9aacee942089fff546c014655579a28
+size 105883

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.50.2/2023-06-29T21:37:30.061824+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.50.2/2023-06-29T21:37:30.061824+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47278b1cfdb0ed94730e82412f717b43eb1abf1b2171c631aef47b22fda8d204
+size 811

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:02+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:02+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21477390392117e91cacd3ea7affa034c863e95335419744c717b2eb8b0eb1f2
-size 93433

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:02+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:02+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:624776b762fd3150c00e89c67d307fbf6bc8843f418a39f9a36d99218e0dbe92
-size 965

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:30.120798+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:30.120798+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07769619db1a94622b430a7a9137eda480319f351e7b5841cbf6782ad8cb96d8
+size 108968

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:30.120798+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:30.120798+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72049ff636002ccc54ec600514fe65b3906c3461c4e9aa181a0dcc1d26566558
+size 890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.7.0/2023-03-09T17:32:17+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.7.0/2023-03-09T17:32:17+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:89ef2a5fad8daed5c94735ef0946316970fb655618346cc2a7b0a3aa2b69d268
-size 145017

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.7.0/2023-03-09T17:32:17+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.7.0/2023-03-09T17:32:17+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2dce24a0120afd178573887b2501edbccfa2e2cb2e6ac0b42b1dc95ecd18c22
-size 624

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.7.0/2023-06-29T21:29:10.950192+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.7.0/2023-06-29T21:29:10.950192+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d29ad8c4ad2581007d5574a71ea1c223ca529dcb5b6fa76418787904bb0fee6
+size 159172

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.7.0/2023-06-29T21:29:10.950192+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:347fba6fbfa15d4e11217f9d49bf70a5a6eef35c6c642dc8c5db89115912d0c1/grype@v0.7.0/2023-06-29T21:29:10.950192+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c72e9160caf0612681fe59aaebf9978ab8826092be8ba47641076be5830381c9
+size 549

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.12.1/2023-03-09T17:35:27+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.12.1/2023-03-09T17:35:27+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd9d98009ce65f832aee0f9e5dcf5c90a38858f1b119ff86f2dab600b8c7c274
-size 17479

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.12.1/2023-03-09T17:35:27+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.12.1/2023-03-09T17:35:27+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c557b3175b7e7d42068aaadee9de117fc806b376f32fb72d5dfbbd39eb4ea60
-size 891

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.12.1/2023-06-29T21:34:01.111499+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.12.1/2023-06-29T21:34:01.111499+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c117bf8ecc1e05810a1a3288a93518264a10c6744a4a8c5e4d06f31c65ef9b3
+size 17424

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.12.1/2023-06-29T21:34:01.111499+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.12.1/2023-06-29T21:34:01.111499+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0faa47aadd751ff0d4be414ae749dfb91b503bec2799c355c3282334af65999
+size 816

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.40.1/2023-03-09T17:37:32+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.40.1/2023-03-09T17:37:32+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4d4fde4157844b9b199bf246964792c84800078682763d8f7678552b7633292
-size 755028

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.40.1/2023-03-09T17:37:32+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.40.1/2023-03-09T17:37:32+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06c76fac5117664e04568476ad5890b9c0ae333e1b0e02354c563e80286046ef
-size 891

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.40.1/2023-06-29T21:35:49.370150+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.40.1/2023-06-29T21:35:49.370150+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb6372ea438588072c21105bba673771a19d04138f71c3865356fefbd6fd9b4
+size 981360

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.40.1/2023-06-29T21:35:49.370150+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.40.1/2023-06-29T21:35:49.370150+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f41de7cfc80232b5c137261758ecc33063d03ca5fca598cf5794c63667ff0ed
+size 816

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.50.2/2023-03-09T17:39:52+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.50.2/2023-03-09T17:39:52+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e0f5b9350029337001a099b94486de1c31c29da06a97a00b5a269018510a23f5
-size 766192

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.50.2/2023-03-09T17:39:52+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.50.2/2023-03-09T17:39:52+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5740ea13ed06f39bddc701cf5fe76fa2194d7f63fe1626d4153be4d5a53b177b
-size 890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.50.2/2023-06-29T21:37:52.234366+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.50.2/2023-06-29T21:37:52.234366+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:276b030f6fb5f9b29222772087e58be06d8cacf3464c65eecacb75de8c9a75bf
+size 995800

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.50.2/2023-06-29T21:37:52.234366+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.50.2/2023-06-29T21:37:52.234366+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de91a423b72d279e2df96ca318d3ded95c651472388c6050198c90528701260f
+size 816

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:22+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:22+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80ed0709b6cac34301583075f30fd37a07e8fcb4a5a377bc0e0ff16089d52f1d
-size 788263

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:22+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:22+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb553c08d327a4bd40aeb1a4894092bd0589bbafba1c6504eb1fa7b906963ed8
-size 969

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:47.699089+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:47.699089+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b7262c0c32b1346fe7013b7eed44374ec88e7033c6ae78e9c4634f401ddacb4
+size 1024782

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:47.699089+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:47.699089+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b31443a9ae65f4db836ec19b59d53d95dbf145b19c88ce3a1513e5f2b8e50326
+size 895

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.7.0/2023-03-09T17:33:20+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.7.0/2023-03-09T17:33:20+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:832ccf0b38f50cbd81e7adc19c00f11eff6a2b199c645d15084eea60ced0f6f8
-size 16743

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.7.0/2023-03-09T17:33:20+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.7.0/2023-03-09T17:33:20+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:61de7573d7de97162bb13eaad79163778838ebfb4f0f7531602efc578cfb55dc
-size 628

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.7.0/2023-06-29T21:30:26.398765+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.7.0/2023-06-29T21:30:26.398765+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:248f7b8c7a95b2404400ac0bd4556809ecb39a75c02fb7badcbdcb09544fd993
+size 16713

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.7.0/2023-06-29T21:30:26.398765+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:3fa6909fa6f9a8ca8b7f9ba783af8cf84773c14084154073f1f331058ab646cb/grype@v0.7.0/2023-06-29T21:30:26.398765+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c30dd2d4d998e39de91f78e5c923cad3f36d787c3c0ea02a7d2078fadc5db8da
+size 554

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.12.1/2023-03-09T17:35:10+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.12.1/2023-03-09T17:35:10+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76e67473dcd07a9765ac1b4aa6171e0302ee77914598fd611ef369a3d558eccb
-size 288976

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.12.1/2023-03-09T17:35:10+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.12.1/2023-03-09T17:35:10+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19a61f95c8275c153c4b003c339618dec059f5a89fab8408337e8649fcdebe79
-size 890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.12.1/2023-06-29T21:33:46.763212+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.12.1/2023-06-29T21:33:46.763212+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b96c49363d312b27a1ebff358adc1cccf4a635abc88303a3ab47ee5435d8d2db
+size 321734

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.12.1/2023-06-29T21:33:46.763212+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.12.1/2023-06-29T21:33:46.763212+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2453abbd3a6ed06960ce4a9d54747b96f2e6515cb918832ea7c84a73a474ed0
+size 814

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.40.1/2023-03-09T17:37:11+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.40.1/2023-03-09T17:37:11+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5dcb54dd42271375abc878f31c5dce7dc1ad7a87d6342041df7d55b3c2d3cb4
-size 404444

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.40.1/2023-03-09T17:37:11+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.40.1/2023-03-09T17:37:11+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fc458539b382bf30a6c135f94b28cabfca659a3a832c5ae21424e16245fab10
-size 890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.40.1/2023-06-29T21:35:31.177281+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.40.1/2023-06-29T21:35:31.177281+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d04002bf30830931ba43ebdd278c79d43a5199c089ffced5bf7309150ddc2cff
+size 500090

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.40.1/2023-06-29T21:35:31.177281+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.40.1/2023-06-29T21:35:31.177281+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:291f0c8e889f1d13efc1eeeca1f15a0406c3b1740300642154f7212f8ee17422
+size 815

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.50.2/2023-03-09T17:39:30+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.50.2/2023-03-09T17:39:30+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a34476bbe4dc199391662ad2372b324dee006f1737131ebfd94aec356822105
-size 399597

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.50.2/2023-03-09T17:39:30+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.50.2/2023-03-09T17:39:30+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14110a1770d49f268ed8dc41db71c0aa909c34f63b435967777f6869dae4a38e
-size 890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.50.2/2023-06-29T21:37:32.954560+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.50.2/2023-06-29T21:37:32.954560+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:655870defe6b4a2df70634116e09abb50fd47864b96f35bb386dc189952cbd61
+size 495872

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.50.2/2023-06-29T21:37:32.954560+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.50.2/2023-06-29T21:37:32.954560+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e89a55e5774c0b3588c9cbd3350b8ed8a6194484a6790740f057eeacf81f32dc
+size 815

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:05+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:05+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:880001e7ac86fdd822812ce08f255f36152c382292610348ef93bc61019610e5
-size 424739

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:05+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:05+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b6d2c86b370a6accf58756da20ec38cbb4638cbf0ab816d443f565ee74d93bd
-size 969

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:32.509199+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:32.509199+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f522fb1c6e15cb1b3469819de1d675e05669534539a3725108b7239a0160fdd9
+size 534788

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:32.509199+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:32.509199+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac7ceee3a5b856d6f6e4b74a37cfd8fe8a90805c58bb57b2f1dd3d10d5048a79
+size 894

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.7.0/2023-03-09T17:32:20+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.7.0/2023-03-09T17:32:20+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:75d998d9f2db12e42764ecbec42b62b20b5dd1fab448e50557205a85a652e5af
-size 354348

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.7.0/2023-03-09T17:32:20+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.7.0/2023-03-09T17:32:20+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e356963ff806197f2f29deaf13b03e69fe7158febfe4a7feded8308e4d79df83
-size 628

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.7.0/2023-06-29T21:29:17.299041+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.7.0/2023-06-29T21:29:17.299041+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76d6449787568ec8122ee34f8c35418b88c90b2efb5320de13dfa9bf006ee4c0
+size 394383

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.7.0/2023-06-29T21:29:17.299041+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:4b28f61016b9d4ad0c0198343e4cc2bd51029f4a1733ed2c4bcc3e2d0dd71bbc/grype@v0.7.0/2023-06-29T21:29:17.299041+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c344e8f75de79d3b2d154f5745664937479e853279d2476dcf723d744ceda9a0
+size 553

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.12.1/2023-03-09T17:36:00+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.12.1/2023-03-09T17:36:00+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f527e038caaaa7bb9a0e5ccfb894a2cd29abf7743d508d83e99fa49505c1f260
-size 2730629

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.12.1/2023-03-09T17:36:00+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.12.1/2023-03-09T17:36:00+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa73543a1420ac06c8c43a9cecec9860b52bda6d31466f5d26c5cd8fc180932d
-size 878

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.12.1/2023-06-29T21:34:27.323040+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.12.1/2023-06-29T21:34:27.323040+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6e3768639a142e532ae480bc413c3b7ba01f736a66e8a503744b750fcafe608
+size 3029634

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.12.1/2023-06-29T21:34:27.323040+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.12.1/2023-06-29T21:34:27.323040+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb9732b66546ed8a083c48cc8d162c733d92f2ef413df419f8e71e95e5f0d268
+size 803

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.40.1/2023-03-09T17:38:13+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.40.1/2023-03-09T17:38:13+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7fa531f19e4582bdd71233d34aeeaf5e8054cef2b6ebb88f2b9cf165f1dcd15
-size 5172151

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.40.1/2023-03-09T17:38:13+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.40.1/2023-03-09T17:38:13+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8208fad1b4e5663d28bd84e4d87176bd7e11031c1494c6eefd09eda00a17710b
-size 878

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.40.1/2023-06-29T21:36:23.157017+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.40.1/2023-06-29T21:36:23.157017+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef6833173959f6d92862d1dcd71be6ff16c388ee5441ea163e2cfd7c2ca6f1af
+size 6081629

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.40.1/2023-06-29T21:36:23.157017+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.40.1/2023-06-29T21:36:23.157017+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd6ab7838c9c35670d92a47137b491761be5d40de8527afd13bbe15ef501e44f
+size 802

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.50.2/2023-03-09T17:40:33+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.50.2/2023-03-09T17:40:33+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d1c65b76a8287ded8c3402411f80dd3f2c7ddbfcf4edef9090a099e8512fa39
-size 5230852

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.50.2/2023-03-09T17:40:33+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.50.2/2023-03-09T17:40:33+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd6f7a20f6909bc8e2843a55d2eff25e6a8ca5f4389d4e205bd840da4a160125
-size 878

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.50.2/2023-06-29T21:38:26.285716+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.50.2/2023-06-29T21:38:26.285716+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0f7b3495a8cd6428250ce31c162d8b29542a1751a2a92c2c06dabeea61e6862
+size 6152187

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.50.2/2023-06-29T21:38:26.285716+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.50.2/2023-06-29T21:38:26.285716+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ce4aa41c56920742ab16611783e0cd55daeb1b376b0a33ba01d01c3e17a6524
+size 802

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:54+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:54+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c92253e1ffa9f991154c3b4c1ef10bdd74b241b39e1d2d8f9b1e87ffd3285cd2
-size 3753199

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:54+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:54+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d0876f80844b9d1d7309b1303303b314d9118c39726f816fea9f38fa81c0ca4
-size 957

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:40:12.277710+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:40:12.277710+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92f497776a309ceaea2fd1ade7d85115690378ae6e93d673ba6e9512aa6e5640
+size 4286820

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:40:12.277710+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:40:12.277710+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4daf0f9865b2ec90f5b0d90962d96b49df260eb9a014baef0a106feb72bd3fe0
+size 882

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.7.0/2023-03-09T17:33:59+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.7.0/2023-03-09T17:33:59+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:810ba27262a796c0c7918bd04aa114f6c91afe2c7d9b60c7cfa3779eb3563c92
-size 2998001

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.7.0/2023-03-09T17:33:59+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.7.0/2023-03-09T17:33:59+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:085ac341d239a210ce51bf29e2e4543ee6bdea11dbfdedaec939525573a7cc87
-size 616

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.7.0/2023-06-29T21:32:20.655061+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.7.0/2023-06-29T21:32:20.655061+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6be40caf94e49b42f38e2f0086ed530e145705c67c601e7d0797e7175bb0a92f
+size 3325227

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.7.0/2023-06-29T21:32:20.655061+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b/grype@v0.7.0/2023-06-29T21:32:20.655061+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aa631c30bc7c660277dab901aaf71b38c2d0f676f2032f3ed971bdffda657af
+size 541

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.12.1/2023-03-09T17:34:43+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.12.1/2023-03-09T17:34:43+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d79415352b9c8abe91f899316827e61bd642b3e323fa74ff957b66c953f14b6
-size 79647

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.12.1/2023-03-09T17:34:43+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.12.1/2023-03-09T17:34:43+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98cb5673ae680d76c50af0c337a2f05b63ab1f38c737f21cd2caa7058a80e593
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.12.1/2023-06-29T21:33:22.918903+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.12.1/2023-06-29T21:33:22.918903+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:522423bbf5e74395d3e061430804cdd401da2915bfd7fb69ea03cf5bb4c2cc8e
+size 91624

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.12.1/2023-06-29T21:33:22.918903+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.12.1/2023-06-29T21:33:22.918903+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e70a813726fd99c8417d0bf6f305af034b75cb5fb20a3ccdfb8c90ff86e5ef8
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.40.1/2023-03-09T17:36:39+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.40.1/2023-03-09T17:36:39+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e22ee20ebe87cf60dd06d2fabc9646e587b345a6545827adb7b1e140fc8d37cb
-size 72415

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.40.1/2023-03-09T17:36:39+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.40.1/2023-03-09T17:36:39+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08528b881d317074e3be8217489d88d2539654d60f93d33becd622e86a12b441
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.40.1/2023-06-29T21:35:03.067311+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.40.1/2023-06-29T21:35:03.067311+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5f6fd7765bd0df220b124f269495007ceac746c92e767ef8c9f51158cd1d905
+size 100281

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.40.1/2023-06-29T21:35:03.067311+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.40.1/2023-06-29T21:35:03.067311+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3860cfa15f5a5f104ac4a09a3027624dbfecd79cf0dc11dd23b95e7a7a7fc48f
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.50.2/2023-03-09T17:38:58+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.50.2/2023-03-09T17:38:58+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2819221f0acd1f8d164f288f938a4b5ad305c6a63b9c77975c3d160565307530
-size 73109

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.50.2/2023-03-09T17:38:58+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.50.2/2023-03-09T17:38:58+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7344bfbad6a313c19a9f3eb5d6a843c13290247cbc2d2d5e9c6d50b21b55b37a
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.50.2/2023-06-29T21:37:03.214540+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.50.2/2023-06-29T21:37:03.214540+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:325c4e9112416b19f467203bed6a5a24eb963ea33c6950eb93f2fbca2f71a0e0
+size 101039

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.50.2/2023-06-29T21:37:03.214540+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.50.2/2023-06-29T21:37:03.214540+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3081a0150061afae0807e4f08cb66eadafb6a5e2c9a9415d10edf28565abebc1
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:34+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:34+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a04f12a443f0d11a1edce814532da567dd9afe3d641cb70e86d0880954bb620
-size 119241

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:34+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:34+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e064a3a189b6eab65a61ec8718649cecd1d27398eb1c476a4cecb77598177931
-size 966

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:05.018390+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:05.018390+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97046d74c230486850ea74bc1a5fd44ba21e66b8320f53e2049061d02037d9a7
+size 158712

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:05.018390+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:05.018390+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79a6bb4d945a732815de9712d8e6de4ce84669f328fe38cd27cdf8bc762a5def
+size 892

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.7.0/2023-03-09T17:31:44+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.7.0/2023-03-09T17:31:44+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:900e037c4cecf1d3c43e7bc67ff1b5b2232cdee6178aff3a45c47e38f30bf31a
-size 17126

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.7.0/2023-03-09T17:31:44+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.7.0/2023-03-09T17:31:44+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a6422d5d63397678274d17f9772064045ff9a9071b8b49ebc3eb55d0006f35d
-size 626

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.7.0/2023-06-29T21:27:33.711601+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.7.0/2023-06-29T21:27:33.711601+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2afccbcbcf02a9c0be56e2c94c2644ee8dfcbb3a84a318182308b13dbf9ff82b
+size 17402

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.7.0/2023-06-29T21:27:33.711601+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:55c9ba4e24e15c0467a071d93fead0990b8f04bb60b359b4056a997598aa56a1/grype@v0.7.0/2023-06-29T21:27:33.711601+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92c6474bf0e99a443d212dbe2def09e13027fd554356702daf39b81cc072ab93
+size 551

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.12.1/2023-03-09T17:34:47+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.12.1/2023-03-09T17:34:47+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70ca456753a69e34d2132ebfe59cbe3aa8990a6f9325437866048090d1e311d7
-size 54067

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.12.1/2023-03-09T17:34:47+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.12.1/2023-03-09T17:34:47+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:15e4403ccc7ffdfe2ed2f3162f0cec6bd336418ae1f07ff03e9585b52e488458
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.12.1/2023-06-29T21:33:27.272467+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.12.1/2023-06-29T21:33:27.272467+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eb641126f54984f329e6319e8ad4ecb85a8ec44a4f36c6d0d387c9be181da55
+size 59004

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.12.1/2023-06-29T21:33:27.272467+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.12.1/2023-06-29T21:33:27.272467+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9186e5c10fe1f2891342db35eb9948e0aac422026a6498e9f2644e98f3f4e52a
+size 812

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.40.1/2023-03-09T17:36:44+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.40.1/2023-03-09T17:36:44+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93b87f3fb5426f66e38b09c3e752b1bd7c5c3e207db377e046384a8f5050c8c7
-size 102651

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.40.1/2023-03-09T17:36:44+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.40.1/2023-03-09T17:36:44+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c2324d9717cdc954cbc45f1321f5cb8133d91bb5162dd320886d57a8239c557
-size 886

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.40.1/2023-06-29T21:35:07.181276+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.40.1/2023-06-29T21:35:07.181276+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb8973dc6f04c0770fa04e0a9680c266aec6703efc183f4a5e434390905046a4
+size 106422

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.40.1/2023-06-29T21:35:07.181276+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.40.1/2023-06-29T21:35:07.181276+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e863992e9453285c1fad5bcef7dec10a6673c878aa0dae34636c2e42c16bd34c
+size 811

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.50.2/2023-03-09T17:39:03+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.50.2/2023-03-09T17:39:03+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46a6551c17e049243d01bf1ac1e38e7540da3be344f930d97814674185da48cc
-size 103377

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.50.2/2023-03-09T17:39:03+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.50.2/2023-03-09T17:39:03+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f52e2cccb106ba14f2269c2bbe80b50ba66440b71eea5f3d0715e2a00d0109c3
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.50.2/2023-06-29T21:37:08.110414+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.50.2/2023-06-29T21:37:08.110414+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6e4f4748b70f3958876003e85109e9232ca16a8623b6b8a7d55c00a4943f5a1
+size 107156

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.50.2/2023-06-29T21:37:08.110414+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.50.2/2023-06-29T21:37:08.110414+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2848536b0f380340f671e03cdd3a810f70bb2d75b12a04416d460d0532657fef
+size 812

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:40+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:40+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:021f47c2186087b3f061130807a0edab89910432e9bea2458d1655b60e18a344
-size 216330

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:40+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:40+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b10d4e668e4377a708517e64ad5ee90241060db953fe9e843304f4fc67cf1d76
-size 966

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:10.895422+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:10.895422+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1e4fb0a662ea2cebc67cedb3193d055d84cc0eabd636dab1cce4b3b733aa6ce
+size 235973

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:10.895422+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:10.895422+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e2b1930d5736a056f84f91a777becfb534578e5de4ff3bdff5e43a3e051a11e
+size 891

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.7.0/2023-03-09T17:31:48+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.7.0/2023-03-09T17:31:48+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:873d9e53d191e21a67986b2dfb12f2180f5339cf29c0434c20c87c578f39c2be
-size 7997

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.7.0/2023-03-09T17:31:48+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.7.0/2023-03-09T17:31:48+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d0e90957d269a62f8758a3e2cfa4a43ecb2a4b9e1a7d5754b409606faba3253
-size 625

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.7.0/2023-06-29T21:27:50.034451+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.7.0/2023-06-29T21:27:50.034451+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a00d23e607a55616d8a368117a59c18a4cd6caeae2e1861ab7e0cc705fd366d
+size 8032

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.7.0/2023-06-29T21:27:50.034451+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:58637f273108e3e9eb4df4d73f7b6b1da303cbbf64f65e65fb7762482f2de63d/grype@v0.7.0/2023-06-29T21:27:50.034451+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e4e5d22934b7c35bdb80f7d5a5f3a2230e10ac4aada63c0f241894cfc06d9c8
+size 550

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.12.1/2023-03-09T17:34:44+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.12.1/2023-03-09T17:34:44+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc6cb77de9d1b0ce00c6415cda0247d12f482a70018ab30b371042d6c7417b67
-size 23516

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.12.1/2023-03-09T17:34:44+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.12.1/2023-03-09T17:34:44+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e61a09e5553013e0c6c824b916d33e3730173d756ce763ea71ff6af3d5d0a009
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.12.1/2023-06-29T21:33:24.085864+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.12.1/2023-06-29T21:33:24.085864+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:643969f4740b9307874807197cde465972572d785048f2c78b9aeba437be29de
+size 23535

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.12.1/2023-06-29T21:33:24.085864+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.12.1/2023-06-29T21:33:24.085864+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d787442fea88f4fced23b80f86ffa20a2c8780104e49c2ff2370ef6199345502
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.40.1/2023-03-09T17:36:40+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.40.1/2023-03-09T17:36:40+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb5466667122e584245b19ebf3e2cfa55b056e1200a227abff039007ac39e974
-size 58114

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.40.1/2023-03-09T17:36:40+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.40.1/2023-03-09T17:36:40+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5a2fcbe3149590143d8efc71000aadcd10cec6e66bf69e0a3a1a84e3a8e5f0a
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.40.1/2023-06-29T21:35:03.965741+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.40.1/2023-06-29T21:35:03.965741+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:437332cfc03dd2b3946606d6edffc7e812bd91afdc8761f250c9a8004fe40f6e
+size 85224

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.40.1/2023-06-29T21:35:03.965741+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.40.1/2023-06-29T21:35:03.965741+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cff7ef8585e4630a9b79e69d8f3d22994dacbb61f7a936f322ff29390d30c78
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.50.2/2023-03-09T17:38:59+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.50.2/2023-03-09T17:38:59+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b0f96fc5c0f845ead5de967528cb4c307496e04a050184bfd36df8920f2f496
-size 58808

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.50.2/2023-03-09T17:38:59+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.50.2/2023-03-09T17:38:59+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afd0672acbc0c34fe6de0b3b08f45606881f22a213a122e60d20a5e0f6a1ac5a
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.50.2/2023-06-29T21:37:04.585605+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.50.2/2023-06-29T21:37:04.585605+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a30efb3448f25f34552a35af0f8493ada82d9dd29f7afacf51daa6afada5e8e
+size 85982

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.50.2/2023-06-29T21:37:04.585605+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.50.2/2023-06-29T21:37:04.585605+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2d412ccbfc785cd60ceb3ea2504e28fb88a0ff2e04fa81d49ec6c087599ce6e
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:35+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:35+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8762efbd11531030a66d25fb16667aeb72523e374d23229dd8219b0f10126d88
-size 63520

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:35+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:35+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c2d6314f4f20788b496672fb4ab617eac03260069b1d8d07a160f9ae9e5d414
-size 967

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:06.305888+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:06.305888+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c6b7a96e4be6da3ea0663c309e44af22aa6f3ffb65860f8bb588a171dec889e
+size 92526

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:06.305888+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:06.305888+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:115b043b68dbb31b2627597dc2d98fe23edea049154d57653496dca106d1551b
+size 892

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.7.0/2023-03-09T17:31:45+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.7.0/2023-03-09T17:31:45+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f295c3eef5874cacae648411cb6840492240be48634fdee17aaf73c4c245aac3
-size 14397

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.7.0/2023-03-09T17:31:45+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.7.0/2023-03-09T17:31:45+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d97e4169a42fbbb75b613570c61c61a6462c18aa5669dd3c78c0f018cb8ccbb3
-size 626

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.7.0/2023-06-29T21:27:37.726834+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.7.0/2023-06-29T21:27:37.726834+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0150ccddb61e5625b4a58242275e04cfe0e6c77cfa596eab7e2ffbf566aec57e
+size 14673

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.7.0/2023-06-29T21:27:37.726834+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:6749b1509fc4dd3f2b4e8688325fc5d447751bc9ae3be10c0f1fb92ec062b798/grype@v0.7.0/2023-06-29T21:27:37.726834+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:084a8fb67d0d369477267ad41f44b53174c214d7ca16c35b69612bd88094131f
+size 551

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.12.1/2023-03-09T17:35:00+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.12.1/2023-03-09T17:35:00+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07b4a376dbf78143e3117cf733b69cf5502b4d8282201c57c26b65afd7263761
-size 1178718

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.12.1/2023-03-09T17:35:00+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.12.1/2023-03-09T17:35:00+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14071457d749cc0679d5d068f3c5e7d8719f0e605fc0a5e4b9415761bc927b58
-size 875

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.12.1/2023-06-29T21:33:37.772958+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.12.1/2023-06-29T21:33:37.772958+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3997939148c375959f01f738a1eeea3bed9f9ae1b05c49c5e94d1784d0d46ada
+size 1266472

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.12.1/2023-06-29T21:33:37.772958+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.12.1/2023-06-29T21:33:37.772958+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e48dd0061ddcd4fbd1ba67af5515ba6ff03d538e7d75974da397c7871d71ed
+size 800

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.40.1/2023-03-09T17:36:58+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.40.1/2023-03-09T17:36:58+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdde272b6b017bceff79babebd2558d217f6f1d317a2a546e25fe2f814b22b0f
-size 2951221

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.40.1/2023-03-09T17:36:58+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.40.1/2023-03-09T17:36:58+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a33d4350aa6aebe6aebca68326875e9e8fa6ab2c4f877b3f1705cfbaf2eeb2a
-size 875

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.40.1/2023-06-29T21:35:19.570527+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.40.1/2023-06-29T21:35:19.570527+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f8fa0b195166a899caf820f4d9ed67e469600fcabc88a9e8cd5425552a95e0a
+size 3202517

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.40.1/2023-06-29T21:35:19.570527+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.40.1/2023-06-29T21:35:19.570527+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b310ac564d68b64da19b41597047fbaf86f27f6ea16dada1612c9c5672bcd3
+size 798

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.50.2/2023-03-09T17:39:17+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.50.2/2023-03-09T17:39:17+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dc916f6c201f46971d569c8406333a85d4db2d2a3736e0d71aa3db1970c6750
-size 2976904

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.50.2/2023-03-09T17:39:17+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.50.2/2023-03-09T17:39:17+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:377f387a65342b34195751b1195f0c8f12e659e9add19f5a261f7b73a8620b8c
-size 875

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.50.2/2023-06-29T21:37:20.986048+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.50.2/2023-06-29T21:37:20.986048+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e15cb8e26a921705b48bae40ac4ac33879a167d702e093a5ce73cfcaddc9bb5
+size 3230020

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.50.2/2023-06-29T21:37:20.986048+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.50.2/2023-06-29T21:37:20.986048+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0892e5badf06b4e4ac1988b994b9736de5a512521d6612b2a319d43b1ee14cd7
+size 800

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:53+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:53+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cb9c237e48bbebcba15564e151d7ef1f2ac5d159069d470c82fd6254776b66b
-size 3082514

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:53+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:53+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d1d3c2e096cfa04d0f8c589137a157e319d13495c0bb47381e91fd4e515ea38
-size 953

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:22.025642+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:22.025642+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:018241341148d609be733a6ac6ebef02b91e671156fd410751dd0e5260fe9215
+size 3347754

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:22.025642+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:22.025642+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51044c6968aeefa8da1e648ee70b65bf4828a20c973e3c08d2b6bbc5e6f7f1b2
+size 879

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.7.0/2023-03-09T17:32:04+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.7.0/2023-03-09T17:32:04+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d0991e473e3242289f3224c57e44a8af73fd93c3fd6c15b72ee592bd1b28b7e
-size 1393483

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.7.0/2023-03-09T17:32:04+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.7.0/2023-03-09T17:32:04+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a74cfc506bc769c522358f5c32be76b189396e3c3b4bf6bd75f4689ca89d120
-size 613

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.7.0/2023-06-29T21:28:37.622360+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.7.0/2023-06-29T21:28:37.622360+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0eec3f2dd34005af09e6f680e92c677c19587be57d5d30fe6f1b658f692d3c6
+size 1499298

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.7.0/2023-06-29T21:28:37.622360+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:746d31247006cc06434ce91ccf3523b2c230ff6c378ffed7ca1c60bbb48ea86f/grype@v0.7.0/2023-06-29T21:28:37.622360+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c468c2c55f3f2234517008413ea8089c1f7a65124f9438ae946aa410f7d6918b
+size 538

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.12.1/2023-03-09T17:34:46+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.12.1/2023-03-09T17:34:46+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:245f8366f657bde7189d3ef7d94f988972f2b2b21a543b79facb3aa333518197
-size 215414

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.12.1/2023-03-09T17:34:46+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.12.1/2023-03-09T17:34:46+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce200ca953d95aec6484e9fb19dad49df85df0cd811d84df9a23e43573312346
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.12.1/2023-06-29T21:33:26.241104+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.12.1/2023-06-29T21:33:26.241104+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b33f6d715480f709afffc721f6ae332ecc75ee52548f15db1b1b5cf3fd28921
+size 234770

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.12.1/2023-06-29T21:33:26.241104+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.12.1/2023-06-29T21:33:26.241104+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed23cf7d930b2a3166522ce3191b70fff19a1e17513114cd4a99d81744c2c9b7
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.40.1/2023-03-09T17:36:42+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.40.1/2023-03-09T17:36:42+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb2382087c1e1ea92ef5cdb5e7b89ec940638d577d62c5a4e87c58ddc34839c2
-size 573521

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.40.1/2023-03-09T17:36:42+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.40.1/2023-03-09T17:36:42+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c1745769a069c01c29501dd8ae9d19fe805c90068549aa4bf1dfb45697a6b2c
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.40.1/2023-06-29T21:35:05.893298+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.40.1/2023-06-29T21:35:05.893298+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94a16aed6df95f6ce7ab341f63bbd1e00b4dfc6c755a3585fc39f3dfb7bfda78
+size 712697

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.40.1/2023-06-29T21:35:05.893298+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.40.1/2023-06-29T21:35:05.893298+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa852ced80c300bfb22d845f733f90fe2675264b89faabfaf7171069eb5fbac7
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.50.2/2023-03-09T17:39:02+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.50.2/2023-03-09T17:39:02+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:182dbd4172802fe18edbc2c9e746890719e1eedea57138fdb10036d8c764b469
-size 577111

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.50.2/2023-03-09T17:39:02+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.50.2/2023-03-09T17:39:02+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a1cef144212498b6074781e960e86559d6f4c5310c9d1a1c4f9d2fc0ed0e1b0
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.50.2/2023-06-29T21:37:06.776377+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.50.2/2023-06-29T21:37:06.776377+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deb01e091129655efc5c8fcf893e108701623dafd5bfa858a934aeba1ddb8e9d
+size 716687

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.50.2/2023-06-29T21:37:06.776377+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.50.2/2023-06-29T21:37:06.776377+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fec2577fdb5f0ea9fd73f3ef3d267802fe8566d4f8143115f3283b611fb38130
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:38+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:38+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:313c3bc74354c8c120c2ada4ee570aa45750282c06b1d3880d1e735f43f4a6c7
-size 606396

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:38+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:38+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:edd5d93f0c8b943c8f43bc11c0ef08f5694dc467ebfdf4a9ce234647c8614869
-size 967

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:09.330420+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:09.330420+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c156c0a562a41fecc4e59314a4b0ddaaef3668f5f5db0a4f6a6225043f7a660f
+size 748530

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:09.330420+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:09.330420+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:094b7e359d63a695548cc3e47b6e5247450c64e5bfbc9180fdf5a0ac2d9f9d00
+size 892

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.7.0/2023-03-09T17:31:47+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.7.0/2023-03-09T17:31:47+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d98eb447f5c63941fad524fe39bef60562ca4782df7ca1eed2b3e6a3389500cd
-size 100176

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.7.0/2023-03-09T17:31:47+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.7.0/2023-03-09T17:31:47+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82455abf185b400fc9d5ac3a553856a25ce64b8f5fb83e8ee1e00f0ebd33f39b
-size 626

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.7.0/2023-06-29T21:27:45.358455+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.7.0/2023-06-29T21:27:45.358455+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a321da39a9364a110c4e2e351dbf55a8760fe76ecd9a2c81ebe42b4ab01e579
+size 100654

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.7.0/2023-06-29T21:27:45.358455+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:7790691e5efae8bfe9cf4a4447312318d8daaf05ffd5f265ae913edf660f4653/grype@v0.7.0/2023-06-29T21:27:45.358455+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3ef2862fafec73d385bf96a4d8facf0d88f0d50f6eac9a98322eef52cfa0744
+size 551

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.12.1/2023-03-09T17:35:30+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.12.1/2023-03-09T17:35:30+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:807f6f7581e1225c8727d1eeb0163875a660e439ea23fe7f9b63350f7e452a0f
-size 2796339

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.12.1/2023-03-09T17:35:30+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.12.1/2023-03-09T17:35:30+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c84f4e1941e504ec88160ee0e46389e14e123340f46f6d60b37d32a0afa86d9b
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.12.1/2023-06-29T21:34:03.530095+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.12.1/2023-06-29T21:34:03.530095+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ee13db656d758c2dbd163c33f87dd9fe00fb8731caf54c8de2e6afc47c4cca6
+size 3093858

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.12.1/2023-06-29T21:34:03.530095+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.12.1/2023-06-29T21:34:03.530095+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6332640739b25d9bcf339f6c35b2b2f86eeeb2d6e46d172872f2e867aed73b81
+size 812

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.40.1/2023-03-09T17:37:35+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.40.1/2023-03-09T17:37:35+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d296a1aa3b396a2077ca0cbfc49fa222dd0dbef6e77bb3a91f96a98e9ee0d62
-size 5442196

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.40.1/2023-03-09T17:37:35+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.40.1/2023-03-09T17:37:35+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0248cc537b060e6392931e205d279cb3184d2865b665aaa69bca5407d545bf0
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.40.1/2023-06-29T21:35:52.604498+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.40.1/2023-06-29T21:35:52.604498+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa32db3f5d216587d262be7fa4f149ca99a7be30e87ac1d5710418f3b4c7a318
+size 6351180

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.40.1/2023-06-29T21:35:52.604498+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.40.1/2023-06-29T21:35:52.604498+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f41709483b303997beb3672726e59858d5b426525c1243ad63a9b4ce02701bc5
+size 812

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.50.2/2023-03-09T17:39:56+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.50.2/2023-03-09T17:39:56+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1007113709770f037f32e7873a12611446ac15e6a4c6dbdf084243e089417ee8
-size 5497616

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.50.2/2023-03-09T17:39:56+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.50.2/2023-03-09T17:39:56+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ffab2813b69c6226d095b53bb969e8391d986ecb6045c2194573e363e77378a
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.50.2/2023-06-29T21:37:55.564253+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.50.2/2023-06-29T21:37:55.564253+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de88e98a9e5d6ede4e71a0db5c4ebd73336fb4184bf57154dfab6a8747eba7f7
+size 6417969

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.50.2/2023-06-29T21:37:55.564253+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.50.2/2023-06-29T21:37:55.564253+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c878f59cdff83afd921ba1a34b386a457f3446820a97309d290aaf8b81ba97e
+size 811

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:26+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:26+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6b81693dd61796e50065d49862b9eb9f78639406c649683903b3a9fd7489931
-size 4287046

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:26+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:26+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3434278bc78c48ec40cfae63cac2bf3163b2abda2d2be83f4bbd723169608412
-size 966

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:50.372304+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:50.372304+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f19374a5b33dfdf880e41b25f4a5a8dc8429b62b87798d90cf5cffb10a56c752
+size 4823040

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:50.372304+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:50.372304+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abf2b6d770612b830b91ffcfbfc534ffff6068e412911d63fb467ed5d8abbd7b
+size 891

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.7.0/2023-03-09T17:33:23+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.7.0/2023-03-09T17:33:23+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0332a79a74a83790a1f38f54a3247c768500dc0bbb4cad4adcf52af0737cd640
-size 3073314

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.7.0/2023-03-09T17:33:23+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.7.0/2023-03-09T17:33:23+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:602725093040704a94e3b1cac3df875155d3ac011a28f0de2ef665aded61e963
-size 625

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.7.0/2023-06-29T21:30:38.472093+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.7.0/2023-06-29T21:30:38.472093+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f0e246c297758bd767e5189f324653b6224f7b39715dbd15b98bbc16f47cf1d
+size 3399544

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.7.0/2023-06-29T21:30:38.472093+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:808f6cf3cf4473eb39ff9bb47ead639d2ed71255b75b9b140162b58c6102bcc9/grype@v0.7.0/2023-06-29T21:30:38.472093+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:198b4b797cf9d15282557825bfe6ac6de10d2d90f67ab7717c90d489c7d3345b
+size 550

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.12.1/2023-03-09T17:35:24+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.12.1/2023-03-09T17:35:24+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe15404fdd77b3ea515bcde3ef3e9f8ed872584a271e893408735b72d5026dbe
-size 375518

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.12.1/2023-03-09T17:35:24+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.12.1/2023-03-09T17:35:24+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c424085bc756b3620f0f72ec27018ea129b44496f46a4cbf0e804707a86d6e6e
-size 889

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.12.1/2023-06-29T21:33:58.256368+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.12.1/2023-06-29T21:33:58.256368+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c05eaec3996dce59914e19da679cc18c59585a528ed1f5c2e02f490dfed327b
+size 444117

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.12.1/2023-06-29T21:33:58.256368+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.12.1/2023-06-29T21:33:58.256368+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93f721f89d9c857753cf43f9d42926c9c506c0b384182cd9c48af015e47c46bc
+size 814

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.40.1/2023-03-09T17:37:28+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.40.1/2023-03-09T17:37:28+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9775d364df5a4f2abc11d9f4634139e7d141bf421edb3a41d9ca72a43abb8e6e
-size 805602

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.40.1/2023-03-09T17:37:28+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.40.1/2023-03-09T17:37:28+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5db77edbd68f4d578179735aac9724cf433cc038687e003858023cbcebd67fc9
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.40.1/2023-06-29T21:35:45.979878+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.40.1/2023-06-29T21:35:45.979878+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9695b307d6d71223140fa2ab6406a46e14acbdb2e00adafc9441194d9e2bfe5a
+size 995768

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.40.1/2023-06-29T21:35:45.979878+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.40.1/2023-06-29T21:35:45.979878+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:378ef3775bdb2f1b20872081bb482b0622f24a02f042d67112ba0b18b57ef99f
+size 814

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.50.2/2023-03-09T17:39:48+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.50.2/2023-03-09T17:39:48+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e93b10a5ea10399f8a0f5a36d0f36695497abc673bcf5e6188c2487ddfec31e
-size 790607

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.50.2/2023-03-09T17:39:48+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.50.2/2023-03-09T17:39:48+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4bd68a6b08917556405e371b7665da16fc5560a1ec79a80ce80730a1fa3b2228
-size 889

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.50.2/2023-06-29T21:37:47.918884+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.50.2/2023-06-29T21:37:47.918884+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbdf8447d6295c7bf1b399895034cf1a42e8fe0d608fb87047d8677e858741fb
+size 980609

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.50.2/2023-06-29T21:37:47.918884+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.50.2/2023-06-29T21:37:47.918884+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec8e0724b7ed170c3fe42069a030a4379a050c279dfdb4906340d9216ed30205
+size 814

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:18+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:18+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6faf5dd5bc25e55c2da0891d1c0b99b6acaea9ff8a05104ec40f928b4225e048
-size 802197

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:18+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:18+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cacebb2e0596cd79ae1fa789047cc21bd615d664d4736b904451e52fbdfd2228
-size 966

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:43.973800+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:43.973800+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e83bb90b531ea46d00de0cb3e15fd31b16fd86df33e03056afa262963cef5f7a
+size 998985

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:43.973800+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:43.973800+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d243f61910b7041009aaae9857d90e4f813e086c04ce3f73e07296fa547378d6
+size 893

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.7.0/2023-03-09T17:33:09+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.7.0/2023-03-09T17:33:09+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c793488e4e664ad6b4db9c4000a862667e48126ebcda1e6d1c1736bc6f03207
-size 449647

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.7.0/2023-03-09T17:33:09+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.7.0/2023-03-09T17:33:09+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f6f174329c13b704f59b02b486712f62f09f18f4a83aa18f63f1a842b43fcb4
-size 627

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.7.0/2023-06-29T21:30:11.664461+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.7.0/2023-06-29T21:30:11.664461+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:070b3d693d9e64ba08f2a37da0fbdffb3cae7327f492d550cdb57b01dc881434
+size 528692

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.7.0/2023-06-29T21:30:11.664461+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:835483c1a36f6cf50bbf84dcef135b4640ea7d8eb9cf15b9edc4f1734f8335d4/grype@v0.7.0/2023-06-29T21:30:11.664461+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c507fd679ce3233cc166d6c1eb0dd0cc807a119fab8526f46fe3198133fd1b60
+size 552

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.12.1/2023-03-09T17:35:05+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.12.1/2023-03-09T17:35:05+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19904c1d89b33849200aa0623aa57b9a25568837899d6defeb8f71c74fd5b31f
-size 727028

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.12.1/2023-03-09T17:35:05+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.12.1/2023-03-09T17:35:05+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc7a435073b49aaa16efb49eb42b754c10fd99bf33efdeb7e208d1816a82f9be
-size 875

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.12.1/2023-06-29T21:33:42.457290+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.12.1/2023-06-29T21:33:42.457290+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b26e5c93bc00f7981134f0b114f268221d9433760ec6e8bcc37954c27667922
+size 864623

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.12.1/2023-06-29T21:33:42.457290+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.12.1/2023-06-29T21:33:42.457290+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbfe28aeb80d236fb4281749f8a98779979d998a6110bc83973f3bf217fcafb3
+size 799

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.40.1/2023-03-09T17:37:05+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.40.1/2023-03-09T17:37:05+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d545e431628abb564d12371155404c52a1201d3686a0f04bd8a87b5cd53e9c41
-size 1506518

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.40.1/2023-03-09T17:37:05+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.40.1/2023-03-09T17:37:05+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e23be2d1c39ab75649f5660f0cf8c6cbbef9fdf9aae0cfc4f589e950d2c2658b
-size 875

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.40.1/2023-06-29T21:35:25.572146+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.40.1/2023-06-29T21:35:25.572146+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb9cf126468a9cb8e961d192dd705aa850c942f34415c634985fc8d9f7b3473d
+size 1817404

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.40.1/2023-06-29T21:35:25.572146+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.40.1/2023-06-29T21:35:25.572146+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63145c11b3569068cc6b661d1867f27a16b6d1a41548c339dce104510dc61047
+size 800

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.50.2/2023-03-09T17:39:24+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.50.2/2023-03-09T17:39:24+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e4ecdb661ba78c9fd73a4383358671da8f77994e905f4f1e6544214bed6272e4
-size 1507255

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.50.2/2023-03-09T17:39:24+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.50.2/2023-03-09T17:39:24+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24dc9508c62741926e8cd343c2aae7e2d5cd1b98260d3c15b282eedd3f694042
-size 875

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.50.2/2023-06-29T21:37:27.097842+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.50.2/2023-06-29T21:37:27.097842+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0be8727a7d43b899032cf53dc313c6ce50e5dcabe79302bb6c346f64c051973c
+size 1819561

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.50.2/2023-06-29T21:37:27.097842+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.50.2/2023-06-29T21:37:27.097842+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b4c63a7aa9eb96bca2c833ef54424aaa1e74d586fa445d58646afd25e97ad91
+size 799

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:59+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:59+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b4773cd0ae07824eccc332c86d4878d7732935d6fbdf3dbf57a48a652cce45f
-size 1520719

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:59+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:59+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b58f7cc717fb3faa396de477d3e797f5fa8ec317717bd2599522df7927915a38
-size 954

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:27.428740+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:27.428740+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:199603bb22393b963b320ab88ed6f6fcbb36754ff24f89133e9f585da457c22f
+size 1839456

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:27.428740+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:27.428740+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed5966e28759ec86237c569e37391862dd3e2235191ebca29874fc9e33c817e1
+size 877

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.7.0/2023-03-09T17:32:11+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.7.0/2023-03-09T17:32:11+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71bf1cb95f49501a93c4b60b598414ddd02e56169dc91b6e02efc75b72ff486a
-size 821944

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.7.0/2023-03-09T17:32:11+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.7.0/2023-03-09T17:32:11+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14ac18e8ffcd51452aeba7ba8a9cdfb876a7865bafb837f89f3d260198dd62a1
-size 613

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.7.0/2023-06-29T21:28:59.977437+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.7.0/2023-06-29T21:28:59.977437+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5139a3e65152a83df60dd4e13cdc79f96b1861702afb093bdbe1cc8f1cbeac0
+size 972835

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.7.0/2023-06-29T21:28:59.977437+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:88e3684e2284fd61531cafd61a5fe3ce1258bcad2b7d4038bc0116abe59cb358/grype@v0.7.0/2023-06-29T21:28:59.977437+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2072f6e0b40c044f5f71da98d5baaf3015f2de59c5779504b81e8c2b7853afa4
+size 537

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.12.1/2023-03-09T17:35:26+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.12.1/2023-03-09T17:35:26+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5307b407408058175eb553cc321526ad028fce4b8af1b4fa2c7936b474a25874
-size 53864

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.12.1/2023-03-09T17:35:26+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.12.1/2023-03-09T17:35:26+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:861bcdd17323e78c2d82df952236dd7b356591d09fa982799eb4fbca985bd61f
-size 903

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.12.1/2023-06-29T21:34:00.450645+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.12.1/2023-06-29T21:34:00.450645+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f18d1300a973634a0f128b8c568ccdbe915dc6935a45ac8935ed99c207d65f2d
+size 53890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.12.1/2023-06-29T21:34:00.450645+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.12.1/2023-06-29T21:34:00.450645+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cbf781dbb0e7ebb7557b729397a7e8a5370e6f34b5bdad0f1d6b4136cb11a0b
+size 828

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.40.1/2023-03-09T17:37:31+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.40.1/2023-03-09T17:37:31+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd089d2b8a3bf841d85d58eacd84c49da52da78171263205b5b5ddc8482450fa
-size 53025

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.40.1/2023-03-09T17:37:31+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.40.1/2023-03-09T17:37:31+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a32395c8514014b76f6d44e748be7fca84f0468693ce850769596915b88b666c
-size 903

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.40.1/2023-06-29T21:35:48.868133+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.40.1/2023-06-29T21:35:48.868133+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d7118b9377156cde985c86f8a4fc57c83b297395af8a090f17021465335a2a7
+size 53268

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.40.1/2023-06-29T21:35:48.868133+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.40.1/2023-06-29T21:35:48.868133+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e21d336c4206494889f9cfbc35544d91c218875fa9b7ab60235e7d8599de8d2d
+size 828

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.50.2/2023-03-09T17:39:51+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.50.2/2023-03-09T17:39:51+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13e17dde6bc4002824f69e889bb3d9936fd81820302436309dced76241c2a7ce
-size 85591

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.50.2/2023-03-09T17:39:51+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.50.2/2023-03-09T17:39:51+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f53ff8c493d33f47e6ebdbf7ed5a0dec8cc6e92ae3a00bab5c7f66c1357fa3f
-size 902

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.50.2/2023-06-29T21:37:51.362737+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.50.2/2023-06-29T21:37:51.362737+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f205e315b1ff6787703ae8e075f1366c716ac5e77e26bf253d215148148f17a9
+size 86838

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.50.2/2023-06-29T21:37:51.362737+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.50.2/2023-06-29T21:37:51.362737+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45533f0fb21f3c7029db986abdfcca4a14e759928bd1250a28bc17e30eae859e
+size 828

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:21+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:21+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13a402dfc6e60a1ef7fb5f3f4a485a2d2f90cc0efa4585ce2eb5443559fb1415
-size 101224

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:21+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:21+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b336074903f189d6f375a032a358ffaac894e7fa8d20bcd4ff531be0e09d9de9
-size 982

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:46.655220+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:46.655220+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55d9e06126e7b80eece9808565fe959f90a1b2e3b1cd677ee7049e81d3b36599
+size 105903

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:46.655220+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:46.655220+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7f5405762d6b0725e817c98eee7d487fb0e635b9a635e6500c5d083ad5fdcde
+size 907

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.7.0/2023-03-09T17:33:19+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.7.0/2023-03-09T17:33:19+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94021156a3351dfb39a260bf1688938d720e30f1760f5d72218c672f498b1ce8
-size 41936

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.7.0/2023-03-09T17:33:19+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.7.0/2023-03-09T17:33:19+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:792fe94e37869aae6ab91a9e1c439309ee84c09f640ecfa356df49719e6c1ef1
-size 641

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.7.0/2023-06-29T21:30:23.016786+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.7.0/2023-06-29T21:30:23.016786+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36be746fe217620f6d6821a5b40f0b8ae2668870f636b707f091d8fddcafcf8e
+size 41987

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.7.0/2023-06-29T21:30:23.016786+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:92f1981518e92bf3712ff95cf342f7f4d5fc83fb93a30a36d7d1204e64342199/grype@v0.7.0/2023-06-29T21:30:23.016786+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd443b1251be44a7b2990c5323100bb4fbe9d57fec3b16a4c8d5448ccb4b8fe6
+size 566

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.12.1/2023-03-09T17:34:48+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.12.1/2023-03-09T17:34:48+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c607b275ae5ef533ee9c07e9655ed8f539600c98a4bd31a44b3f129c1650a421
-size 147388

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.12.1/2023-03-09T17:34:48+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.12.1/2023-03-09T17:34:48+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d2415902e0ae92d0de9cb8d7b295d014bdb580d39a14d86c92a3aef6baf3bf6
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.12.1/2023-06-29T21:33:27.987023+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.12.1/2023-06-29T21:33:27.987023+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1527a0cfdf7abe66d71f18be83e83feb7fae84418d72b0421ea91bb18dd85adc
+size 160849

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.12.1/2023-06-29T21:33:27.987023+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.12.1/2023-06-29T21:33:27.987023+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a51a25c5637f7c2aa602d4b87a51fc72c7ffeeae689d70e1a8552ca0622ecce2
+size 812

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.40.1/2023-03-09T17:36:44+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.40.1/2023-03-09T17:36:44+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abb1d27b91e931ca6acd358ad8ed1bd86e2ef121c188244c44ef37280e43024a
-size 142781

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.40.1/2023-03-09T17:36:44+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.40.1/2023-03-09T17:36:44+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac4179c9defcb82fb99033c47e033b0764958100cb55aeacad0db1315206f3b1
-size 886

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.40.1/2023-06-29T21:35:07.746123+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.40.1/2023-06-29T21:35:07.746123+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2742f9db709be6dc5ea2cb7be2572bb44486277890a3c0fb08094f77fa143d24
+size 145062

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.40.1/2023-06-29T21:35:07.746123+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.40.1/2023-06-29T21:35:07.746123+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c54e26086cab5c4eae0cced343204ee73d1d86e0b6d12471ff4338f1cdf8648c
+size 812

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.50.2/2023-03-09T17:39:04+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.50.2/2023-03-09T17:39:04+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2efa2f15423325c04013bb96b896855d0acc1ed6a1cca80e0247b8f57ed0268
-size 143867

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.50.2/2023-03-09T17:39:04+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.50.2/2023-03-09T17:39:04+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:95fd3ca048064c5f0c29d89bb5b9d72da3c6ed591555574ff9423d5554754034
-size 887

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.50.2/2023-06-29T21:37:08.822517+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.50.2/2023-06-29T21:37:08.822517+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b654750b8fa1e9cb9fc81b0c9e322125cc87d95cbd5f02d231226512e02aa9da
+size 146148

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.50.2/2023-06-29T21:37:08.822517+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.50.2/2023-06-29T21:37:08.822517+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96bd977e918c5dd8ec870ccd77d121b55cc486e30ef3fb1c40c6848e5ff4e2cd
+size 812

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:41+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:41+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c64154eaf19da15aa04f5e037dd50c70de10772bcf9e9dfc567d344b546af273
-size 201833

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:41+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:41+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37528598e48aa9b5a64334300a118fe47eb980be41b053dcae6390cde8861e01
-size 966

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:12.476221+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:12.476221+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0aff8ee7dfaae4c22f6d5e9efa10134bbde16bc10b1e030ba872c86c20558bbf
+size 214026

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:12.476221+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:12.476221+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:644fa2ac28da7f4dd39fac676c00d906258ba62ddd32eb2705fbe3dc4baa4031
+size 891

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.7.0/2023-03-09T17:31:49+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.7.0/2023-03-09T17:31:49+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74d0b1d4cb70d6cf6f7863da3e55944ebff9c259e6faebc95f4b893cededda79
-size 27594

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.7.0/2023-03-09T17:31:49+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.7.0/2023-03-09T17:31:49+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a50301caa0c062e67a31ba2d79a20318cf36149a7e470a1fc76387bac57a7e28
-size 625

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.7.0/2023-06-29T21:27:53.072443+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.7.0/2023-06-29T21:27:53.072443+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35fe36e3920ea30a4e3cc00e29305ea26541f44d3f00ab39ec4e634480ea358
+size 27629

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.7.0/2023-06-29T21:27:53.072443+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:a287a0ff98ac343aa710f4f4258d7198e240e9d416d5c7274663564202f832fb/grype@v0.7.0/2023-06-29T21:27:53.072443+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8deae70da8964d695c79c379ed09377313718fb6948f2ffa59e7c3cda03083d1
+size 550

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.12.1/2023-03-09T17:35:48+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.12.1/2023-03-09T17:35:48+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad2be478e6e041ec21952d00f2e8fc73f6a011deb11c2af1e50e6ac810b77711
-size 976619

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.12.1/2023-03-09T17:35:48+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.12.1/2023-03-09T17:35:48+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2718e4fd3456a50bc75254c532b35e7d58e5a68a445ad8e9c4e30ad22d808192
-size 885

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.12.1/2023-06-29T21:34:18.380821+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.12.1/2023-06-29T21:34:18.380821+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f6f7a9606e258a99c31fe2c17fb4a70e53adb3969b70ead46164776dfc0a3f6
+size 1051010

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.12.1/2023-06-29T21:34:18.380821+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.12.1/2023-06-29T21:34:18.380821+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2670cd509e375a3739136ce81368bfa455f96af8c7fa03f4b09a454236dd630d
+size 810

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.40.1/2023-03-09T17:37:59+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.40.1/2023-03-09T17:37:59+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3bbaffad2e2acb2219b742852865138e6fc3b77490ff7788ed72afb21d2bde44
-size 1683368

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.40.1/2023-03-09T17:37:59+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.40.1/2023-03-09T17:37:59+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:979875913c56394c6e95c92b9f665631449aa3bd17fa8a72fbcb99f7509b7e66
-size 885

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.40.1/2023-06-29T21:36:11.575011+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.40.1/2023-06-29T21:36:11.575011+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43a102f2e43ef39be98f00d12278743da92ae5d8f689b96879379ba646c61e6e
+size 1909290

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.40.1/2023-06-29T21:36:11.575011+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.40.1/2023-06-29T21:36:11.575011+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53f760bc7f6da16673a368c2f86f6ffb0184297175d3ca73747a4a17d2f7debb
+size 810

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.50.2/2023-03-09T17:40:18+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.50.2/2023-03-09T17:40:18+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e00ea550ee8842f18035aafeb115d313cee3a25e077fb407339480e15d30f757
-size 1699008

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.50.2/2023-03-09T17:40:18+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.50.2/2023-03-09T17:40:18+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14f586caa0f7379ecf65d2e38a71ea4afb21016781fd5a5aef7bf838b802e50d
-size 885

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.50.2/2023-06-29T21:38:14.617758+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.50.2/2023-06-29T21:38:14.617758+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59d7c9a92162bf5a19533b7b43e8793eb708610c6c9226707ebe2373dfe578cf
+size 1928013

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.50.2/2023-06-29T21:38:14.617758+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.50.2/2023-06-29T21:38:14.617758+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64b1819fef145012354793ad9ba7a029692afeed21a97d623ae660655cbdddd3
+size 810

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:43+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:43+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05c23d18c42ccee0fc022d9c6ce52624808dfc60c2784cb107b8655afe86d0a5
-size 1262174

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:43+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:42:43+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74b7b097b7d2fd7e83f24b3cd27caa3c3543d1c4789bd80ab4ad8a2fa7c956b8
-size 964

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:40:03.908713+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:40:03.908713+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0bdd933606f2d98d819a828392faf4ae49190ffbe561d94d09314531b8aafac
+size 1474669

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:40:03.908713+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:40:03.908713+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:512dd641465481020c51bd8a38c08e112fab0814b27cf1e7ca0904ee3c2426f2
+size 889

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.7.0/2023-03-09T17:33:45+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.7.0/2023-03-09T17:33:45+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a65d73dc9de5e0b813b1e9edb1a5a57a9b6fc2297896f95774a03242077d463c
-size 1146408

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.7.0/2023-03-09T17:33:45+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.7.0/2023-03-09T17:33:45+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ee6c5d861e3b00344b32889b6c8746a7307193d48d2797e749ea1215a1f4b2b
-size 623

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.7.0/2023-06-29T21:31:40.805608+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.7.0/2023-06-29T21:31:40.805608+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9a4bd8bfe66285ce441cad26589d8e6c6381aae2b4ebacd3793a025e6daf414
+size 1231645

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.7.0/2023-06-29T21:31:40.805608+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1/grype@v0.7.0/2023-06-29T21:31:40.805608+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52dda291272d1dfb5fe64d05c034f372f9dd5dc7788d897128692d209bf1b5d1
+size 548

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.12.1/2023-03-09T17:34:49+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.12.1/2023-03-09T17:34:49+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e93725e2b3aba4b1d1a45598904a4f0241827e57bdbea46f0903e2995932c88
-size 1042766

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.12.1/2023-03-09T17:34:49+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.12.1/2023-03-09T17:34:49+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a3d3c3fb81e035c4975f0911fe0f285a9671b205542fcb75036103dca8e92af
-size 890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.12.1/2023-06-29T21:33:28.817497+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.12.1/2023-06-29T21:33:28.817497+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b615cf213fb532791231ee80a242faba058cd97c6ee7fce5ce80745fa25ba63c
+size 1166412

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.12.1/2023-06-29T21:33:28.817497+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.12.1/2023-06-29T21:33:28.817497+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84eef49b036db099f6d7032e1718b85e0ca3c05f6286dc2bbbc202dd3e3caad6
+size 814

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.40.1/2023-03-09T17:36:45+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.40.1/2023-03-09T17:36:45+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c886c9a3113fabc17004592a3abc1486f433ff198176fb63c7d0489df3cc472d
-size 2250261

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.40.1/2023-03-09T17:36:45+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.40.1/2023-03-09T17:36:45+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e0ee46ee5938ddc60769585e3c27304a1eab51f469726c792a5b8c4ad517b6cb
-size 890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.40.1/2023-06-29T21:35:08.511959+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.40.1/2023-06-29T21:35:08.511959+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d403a83c7001fc471dfd624ed1fbbc6238317d10ed5573ee7a784ffb5044b68a
+size 2695291

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.40.1/2023-06-29T21:35:08.511959+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.40.1/2023-06-29T21:35:08.511959+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c2c735dacfb6135dd2f39074f217d94a24d1a4adf61ad882d17281481f49356
+size 815

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.50.2/2023-03-09T17:39:04+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.50.2/2023-03-09T17:39:04+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7edf612da09ac95df6da22c67bd548addd34412c0038bcdd3d17d25fbb2bcfa
-size 2265333

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.50.2/2023-03-09T17:39:04+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.50.2/2023-03-09T17:39:04+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c03f0bb1a54ec08b259dc49811e29068d8cd3fd8985e27a00f2186bd0dd5c8ff
-size 890

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.50.2/2023-06-29T21:37:09.619539+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.50.2/2023-06-29T21:37:09.619539+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c49d1e187631b0f0dd50e328e77307df490259ebc99c5017bc44ba37a066e93f
+size 2714593

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.50.2/2023-06-29T21:37:09.619539+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.50.2/2023-06-29T21:37:09.619539+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cce3e2c2495e90745b00513f2c67ebe46d152062e99065267e73c8f85aac4b9
+size 815

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:42+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:42+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b1c44d9bc74c78248773a829207efb746e011a7bfd5e3c2d2a30515c6c3b219
-size 2366082

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:42+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:42+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f670f3d3a471326b2b9b3395f445ace590682e74bf94fb1fcde782d104619342
-size 969

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:13.666201+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:13.666201+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:883820e93bbe760b0f171d558c15f407a27690040ee2e6d6a55bbaebf3eb23a7
+size 2848238

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:13.666201+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:13.666201+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d19c169f48b46a63acf7c816726d39a9cb1af23013193d634a1e290a63fb068
+size 894

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.7.0/2023-03-09T17:31:50+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.7.0/2023-03-09T17:31:50+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d00b1f342c918da067402ad826c1becb176012926b87394c28949ed7ccd335c
-size 1225362

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.7.0/2023-03-09T17:31:50+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.7.0/2023-03-09T17:31:50+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38ce6f7c4690af1f2f4ab0b81a89a78949af0b656a32abf4de8d87b7f9607a18
-size 628

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.7.0/2023-06-29T21:27:56.891368+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.7.0/2023-06-29T21:27:56.891368+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fb475eec9ecfbf286c74bdc0133db9379f83f91452f3b5f325747c166adf188
+size 1359074

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.7.0/2023-06-29T21:27:56.891368+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa/grype@v0.7.0/2023-06-29T21:27:56.891368+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b68bfc0a3cf8493fc87024ccaf95ca5e5599e845f75bda477f9b8b8d1dfa141a
+size 553

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.12.1/2023-03-09T17:34:45+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.12.1/2023-03-09T17:34:45+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08fe573881675e4375f75c3e7a84103a57bdbd15181c0bd8cbc0a791347a92c4
-size 215414

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.12.1/2023-03-09T17:34:45+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.12.1/2023-03-09T17:34:45+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:080cea86c5f887e1dd2e9577be90c4ca61b390b12a8a5450ae5c9c73ec03220c
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.12.1/2023-06-29T21:33:24.782821+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.12.1/2023-06-29T21:33:24.782821+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f60215a9d6b20852eabc87d14f508aaaeff7fb318fa918214d9f9cbe0b00a9e
+size 234770

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.12.1/2023-06-29T21:33:24.782821+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.12.1/2023-06-29T21:33:24.782821+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:700f793b769a13aba25e56ffb17cb9a41d58a71dd46f0fe4e17ab90589b2f76c
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.40.1/2023-03-09T17:36:41+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.40.1/2023-03-09T17:36:41+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:163b587d10fa7048a93ab1e1e0e976bafa5cb6dcab46bf7021558fa74043a61c
-size 573521

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.40.1/2023-03-09T17:36:41+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.40.1/2023-03-09T17:36:41+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4794774b5e0b22661ea301104a62254480f6613cfd1d7b9424b97192d617559
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.40.1/2023-06-29T21:35:04.581346+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.40.1/2023-06-29T21:35:04.581346+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d366132746fc8b8269bf00d152342904fc961de76c3eea1fe56f0a80b8a8f451
+size 705639

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.40.1/2023-06-29T21:35:04.581346+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.40.1/2023-06-29T21:35:04.581346+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c129a2b81aebfdd4cf48fda3432fc7040c541a373575f98a321743cb638c8255
+size 812

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.50.2/2023-03-09T17:39:00+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.50.2/2023-03-09T17:39:00+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:003e6750f6f391a36210dd879cfddfab678e4b4314bc5d16587d096eb47055f6
-size 577111

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.50.2/2023-03-09T17:39:00+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.50.2/2023-03-09T17:39:00+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac05111085c03ac4182acfd6672250c82ee7b6449c135b85daeeeb5fd7b2104d
-size 888

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.50.2/2023-06-29T21:37:05.436162+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.50.2/2023-06-29T21:37:05.436162+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23846d6c36942ec527f084a4d1fe7a5a044102920550f0fa1acd23e94cd347be
+size 709517

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.50.2/2023-06-29T21:37:05.436162+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.50.2/2023-06-29T21:37:05.436162+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70159be8ecb4662639f40a3c2671ed249a794aa64673acc8b3721d5d6e4035e4
+size 813

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:36+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:36+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:58377ec821e698e4501cf22096767ea2faa0080bf07784fcd3398fcd8d282b7b
-size 606396

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:36+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.59.1-1-g3a4d01b/2023-03-09T17:41:36+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a510886c33b1f6b8421bdcc236ed0dcd527226ce14564a6f6b3bf0ee2849b7a
-size 967

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:07.755416+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:07.755416+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21d4d106e5b406ddc1a8b24678e3ff3073cc1fe30f7592860b25b3b9c0783a3b
+size 741266

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:07.755416+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.59.1-1-g3a4d01b/2023-06-29T21:39:07.755416+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ff486bddcf6d574bf2cfccc15141970112e29ab2b5f34b2a1988680f83f0453
+size 892

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.7.0/2023-03-09T17:31:45+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.7.0/2023-03-09T17:31:45+00:00/data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab2594edde6ecdecda727f834f8d8dfdb16d97b1cc4cb7f503c8ed606e30f74b
-size 100176

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.7.0/2023-03-09T17:31:45+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.7.0/2023-03-09T17:31:45+00:00/metadata.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69ede6583eb72b8b71b43adc80db9e530c4b1b19e4ed544ec36e0f48c2390a73
-size 626

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.7.0/2023-06-29T21:27:40.751671+00:00/data.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.7.0/2023-06-29T21:27:40.751671+00:00/data.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a4e60d6339f278a684975fb9385551a69a36a887e2613b3ade6ae4eb3be08c3
+size 100654

--- a/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.7.0/2023-06-29T21:27:40.751671+00:00/metadata.json
+++ b/test/acceptance/test-fixtures/result/store/anchore+test_images@sha256:fe242a3a63699425317fba0a749253bceb700fb3d63e7a0f6497f53a587e38c5/grype@v0.7.0/2023-06-29T21:27:40.751671+00:00/metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c940bef668fe7d9348ade26284f16314a5f1ca2f41aae9f8f41cfb8b9b696812
+size 551


### PR DESCRIPTION
Due to [improvements in eol label detection](https://github.com/anchore/vunnel/pull/222) for the Ubuntu vunnel provider, grype will now find additional expected matches for the ubuntu images under test, so this regenerates the test fixtures to include those new matches