### PR TITLE
fix: interpret constraints correctly for Amazon Linux Kernel advisories

### DIFF
--- a/pkg/process/v1/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
+++ b/pkg/process/v1/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
@@ -1,0 +1,104 @@
+[
+  {
+    "Vulnerability": {
+      "Name": "ALAS-2021-1704",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3653"
+          },
+          {
+            "Name": "CVE-2021-3656"
+          },
+          {
+            "Name": "CVE-2021-3732"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALAS-2021-1704.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.4-2022-007",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.4-2022-007.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.10-2022-005",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.10-2022-005.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        }
+      ]
+    }
+  }
+]

--- a/pkg/process/v1/transformers/os/transform_test.go
+++ b/pkg/process/v1/transformers/os/transform_test.go
@@ -382,6 +382,73 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "Amazon",
+			numEntries: 3,
+			fixture:    "test-fixtures/amazon-multiple-kernel-advisories.json",
+			vulns: []grypeDB.Vulnerability{
+				{
+					ID:                   "ALAS-2021-1704",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel-headers",
+					VersionConstraint:    "< 4.14.246-187.474.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3653", "CVE-2021-3656", "CVE-2021-3732"},
+					FixedInVersion:       "4.14.246-187.474.amzn2",
+				},
+				{
+					ID:                   "ALAS-2021-1704",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel",
+					VersionConstraint:    "< 4.14.246-187.474.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3653", "CVE-2021-3656", "CVE-2021-3732"},
+					FixedInVersion:       "4.14.246-187.474.amzn2",
+				},
+				{
+					ID:                   "ALASKERNEL-5.4-2022-007",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel-headers",
+					VersionConstraint:    ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3753", "CVE-2021-40490"},
+					FixedInVersion:       "5.4.144-69.257.amzn2",
+				},
+				{
+					ID:                   "ALASKERNEL-5.4-2022-007",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel",
+					VersionConstraint:    ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3753", "CVE-2021-40490"},
+					FixedInVersion:       "5.4.144-69.257.amzn2",
+				},
+				{
+					ID:                   "ALASKERNEL-5.10-2022-005",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel-headers",
+					VersionConstraint:    ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3753", "CVE-2021-40490"},
+					FixedInVersion:       "5.10.62-55.141.amzn2",
+				},
+				{
+					ID:                   "ALASKERNEL-5.10-2022-005",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel",
+					VersionConstraint:    ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3753", "CVE-2021-40490"},
+					FixedInVersion:       "5.10.62-55.141.amzn2",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -394,7 +461,7 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 
 			entries, err := unmarshal.OSVulnerabilityEntries(f)
 			assert.NoError(t, err)
-			assert.Len(t, entries, len(test.vulns))
+			assert.Len(t, entries, test.numEntries)
 
 			var vulns []grypeDB.Vulnerability
 			for _, entry := range entries {

--- a/pkg/process/v2/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
+++ b/pkg/process/v2/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
@@ -1,0 +1,104 @@
+[
+  {
+    "Vulnerability": {
+      "Name": "ALAS-2021-1704",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3653"
+          },
+          {
+            "Name": "CVE-2021-3656"
+          },
+          {
+            "Name": "CVE-2021-3732"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALAS-2021-1704.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.4-2022-007",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.4-2022-007.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.10-2022-005",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.10-2022-005.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        }
+      ]
+    }
+  }
+]

--- a/pkg/process/v2/transformers/os/transform_test.go
+++ b/pkg/process/v2/transformers/os/transform_test.go
@@ -393,6 +393,73 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "Amazon",
+			numEntries: 3,
+			fixture:    "test-fixtures/amazon-multiple-kernel-advisories.json",
+			vulns: []grypeDB.Vulnerability{
+				{
+					ID:                   "ALAS-2021-1704",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel-headers",
+					VersionConstraint:    "< 4.14.246-187.474.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3653", "CVE-2021-3656", "CVE-2021-3732"},
+					FixedInVersion:       "4.14.246-187.474.amzn2",
+				},
+				{
+					ID:                   "ALAS-2021-1704",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel",
+					VersionConstraint:    "< 4.14.246-187.474.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3653", "CVE-2021-3656", "CVE-2021-3732"},
+					FixedInVersion:       "4.14.246-187.474.amzn2",
+				},
+				{
+					ID:                   "ALASKERNEL-5.4-2022-007",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel-headers",
+					VersionConstraint:    ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3753", "CVE-2021-40490"},
+					FixedInVersion:       "5.4.144-69.257.amzn2",
+				},
+				{
+					ID:                   "ALASKERNEL-5.4-2022-007",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel",
+					VersionConstraint:    ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3753", "CVE-2021-40490"},
+					FixedInVersion:       "5.4.144-69.257.amzn2",
+				},
+				{
+					ID:                   "ALASKERNEL-5.10-2022-005",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel-headers",
+					VersionConstraint:    ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3753", "CVE-2021-40490"},
+					FixedInVersion:       "5.10.62-55.141.amzn2",
+				},
+				{
+					ID:                   "ALASKERNEL-5.10-2022-005",
+					RecordSource:         "vulnerabilities:amzn:2",
+					PackageName:          "kernel",
+					VersionConstraint:    ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:        "rpm",
+					Namespace:            "amzn:2",
+					ProxyVulnerabilities: []string{"CVE-2021-3753", "CVE-2021-40490"},
+					FixedInVersion:       "5.10.62-55.141.amzn2",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -405,7 +472,7 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 
 			entries, err := unmarshal.OSVulnerabilityEntries(f)
 			assert.NoError(t, err)
-			assert.Len(t, entries, len(test.vulns))
+			assert.Len(t, entries, test.numEntries)
 
 			var vulns []grypeDB.Vulnerability
 			for _, entry := range entries {

--- a/pkg/process/v3/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
+++ b/pkg/process/v3/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
@@ -1,0 +1,104 @@
+[
+  {
+    "Vulnerability": {
+      "Name": "ALAS-2021-1704",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3653"
+          },
+          {
+            "Name": "CVE-2021-3656"
+          },
+          {
+            "Name": "CVE-2021-3732"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALAS-2021-1704.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.4-2022-007",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.4-2022-007.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.10-2022-005",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.10-2022-005.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        }
+      ]
+    }
+  }
+]

--- a/pkg/process/v3/transformers/os/transform.go
+++ b/pkg/process/v3/transformers/os/transform.go
@@ -36,7 +36,7 @@ func Transform(vulnerability unmarshal.OSVulnerability) ([]data.Entry, error) {
 		// create vulnerability entry
 		allVulns = append(allVulns, grypeDB.Vulnerability{
 			ID:                     vulnerability.Vulnerability.Name,
-			VersionConstraint:      enforceConstraint(fixedInEntry.Version, fixedInEntry.VersionFormat),
+			VersionConstraint:      enforceConstraint(fixedInEntry.Version, fixedInEntry.VersionFormat, vulnerability.Vulnerability.Name),
 			VersionFormat:          fixedInEntry.VersionFormat,
 			PackageName:            fixedInEntry.Name,
 			Namespace:              entryNamespace,
@@ -146,7 +146,28 @@ func getRelatedVulnerabilities(entry unmarshal.OSVulnerability) (vulns []grypeDB
 	return vulns
 }
 
-func enforceConstraint(constraint, format string) string {
+func deriveConstraintFromFix(fixVersion, vulnerabilityID string) string {
+	constraint := fmt.Sprintf("< %s", fixVersion)
+
+	if strings.HasPrefix(vulnerabilityID, "ALASKERNEL-") {
+		// Amazon advisories of the form ALASKERNEL-5.4-2023-048 should be interpreted as only applying to
+		// the 5.4.x kernel line since Amazon issue a separate advisory per affected line, thus the constraint
+		// should be >= 5.4, < {fix version}.  In the future the vunnel schema for OS vulns should be enhanced
+		// to emit actual constraints rather than fixed-in entries (tracked in https://github.com/anchore/vunnel/issues/266)
+		// at which point this workaround in grype-db can be removed.
+
+		components := strings.Split(vulnerabilityID, "-")
+
+		if len(components) == 4 {
+			base := components[1]
+			constraint = fmt.Sprintf(">= %s, < %s", base, fixVersion)
+		}
+	}
+
+	return constraint
+}
+
+func enforceConstraint(constraint, format, vulnerabilityID string) string {
 	constraint = common.CleanConstraint(constraint)
 	if len(constraint) == 0 {
 		return ""
@@ -156,6 +177,6 @@ func enforceConstraint(constraint, format string) string {
 		return common.EnforceSemVerConstraint(constraint)
 	default:
 		// the passed constraint is a fixed version
-		return fmt.Sprintf("< %s", constraint)
+		return deriveConstraintFromFix(constraint, vulnerabilityID)
 	}
 }

--- a/pkg/process/v3/transformers/os/transform_test.go
+++ b/pkg/process/v3/transformers/os/transform_test.go
@@ -579,6 +579,147 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "Amazon",
+			numEntries: 3,
+			fixture:    "test-fixtures/amazon-multiple-kernel-advisories.json",
+			vulns: []grypeDB.Vulnerability{
+				{
+					ID:                "ALAS-2021-1704",
+					PackageName:       "kernel-headers",
+					VersionConstraint: "< 4.14.246-187.474.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amzn:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3653",
+							Namespace: "nvd",
+						},
+						{
+							ID:        "CVE-2021-3656",
+							Namespace: "nvd",
+						},
+						{
+							ID:        "CVE-2021-3732",
+							Namespace: "nvd",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"4.14.246-187.474.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALAS-2021-1704",
+					PackageName:       "kernel",
+					VersionConstraint: "< 4.14.246-187.474.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amzn:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3653",
+							Namespace: "nvd",
+						},
+						{
+							ID:        "CVE-2021-3656",
+							Namespace: "nvd",
+						},
+						{
+							ID:        "CVE-2021-3732",
+							Namespace: "nvd",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"4.14.246-187.474.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.4-2022-007",
+					PackageName:       "kernel-headers",
+					VersionConstraint: ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amzn:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.4.144-69.257.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.4-2022-007",
+					PackageName:       "kernel",
+					VersionConstraint: ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amzn:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.4.144-69.257.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.10-2022-005",
+					PackageName:       "kernel-headers",
+					VersionConstraint: ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amzn:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.10.62-55.141.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.10-2022-005",
+					PackageName:       "kernel",
+					VersionConstraint: ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amzn:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.10.62-55.141.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -591,7 +732,7 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 
 			entries, err := unmarshal.OSVulnerabilityEntries(f)
 			require.NoError(t, err)
-			require.Len(t, entries, len(test.vulns))
+			require.Len(t, entries, test.numEntries)
 
 			var vulns []grypeDB.Vulnerability
 			for _, entry := range entries {

--- a/pkg/process/v4/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
+++ b/pkg/process/v4/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
@@ -1,0 +1,104 @@
+[
+  {
+    "Vulnerability": {
+      "Name": "ALAS-2021-1704",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3653"
+          },
+          {
+            "Name": "CVE-2021-3656"
+          },
+          {
+            "Name": "CVE-2021-3732"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALAS-2021-1704.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.4-2022-007",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.4-2022-007.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.10-2022-005",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.10-2022-005.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        }
+      ]
+    }
+  }
+]

--- a/pkg/process/v4/transformers/os/transform.go
+++ b/pkg/process/v4/transformers/os/transform.go
@@ -36,7 +36,7 @@ func Transform(vulnerability unmarshal.OSVulnerability) ([]data.Entry, error) {
 		// create vulnerability entry
 		allVulns = append(allVulns, grypeDB.Vulnerability{
 			ID:                     vulnerability.Vulnerability.Name,
-			VersionConstraint:      enforceConstraint(fixedInEntry.Version, fixedInEntry.VersionFormat),
+			VersionConstraint:      enforceConstraint(fixedInEntry.Version, fixedInEntry.VersionFormat, vulnerability.Vulnerability.Name),
 			VersionFormat:          fixedInEntry.VersionFormat,
 			PackageName:            grypeNamespace.Resolver().Normalize(fixedInEntry.Name),
 			Namespace:              entryNamespace,
@@ -182,7 +182,28 @@ func getRelatedVulnerabilities(entry unmarshal.OSVulnerability) (vulns []grypeDB
 	return vulns
 }
 
-func enforceConstraint(constraint, format string) string {
+func deriveConstraintFromFix(fixVersion, vulnerabilityID string) string {
+	constraint := fmt.Sprintf("< %s", fixVersion)
+
+	if strings.HasPrefix(vulnerabilityID, "ALASKERNEL-") {
+		// Amazon advisories of the form ALASKERNEL-5.4-2023-048 should be interpreted as only applying to
+		// the 5.4.x kernel line since Amazon issue a separate advisory per affected line, thus the constraint
+		// should be >= 5.4, < {fix version}.  In the future the vunnel schema for OS vulns should be enhanced
+		// to emit actual constraints rather than fixed-in entries (tracked in https://github.com/anchore/vunnel/issues/266)
+		// at which point this workaround in grype-db can be removed.
+
+		components := strings.Split(vulnerabilityID, "-")
+
+		if len(components) == 4 {
+			base := components[1]
+			constraint = fmt.Sprintf(">= %s, < %s", base, fixVersion)
+		}
+	}
+
+	return constraint
+}
+
+func enforceConstraint(constraint, format, vulnerabilityID string) string {
 	constraint = common.CleanConstraint(constraint)
 	if len(constraint) == 0 {
 		return ""
@@ -192,6 +213,6 @@ func enforceConstraint(constraint, format string) string {
 		return common.EnforceSemVerConstraint(constraint)
 	default:
 		// the passed constraint is a fixed version
-		return fmt.Sprintf("< %s", constraint)
+		return deriveConstraintFromFix(constraint, vulnerabilityID)
 	}
 }

--- a/pkg/process/v4/transformers/os/transform_test.go
+++ b/pkg/process/v4/transformers/os/transform_test.go
@@ -578,6 +578,147 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "Amazon",
+			numEntries: 3,
+			fixture:    "test-fixtures/amazon-multiple-kernel-advisories.json",
+			vulns: []grypeDB.Vulnerability{
+				{
+					ID:                "ALAS-2021-1704",
+					PackageName:       "kernel-headers",
+					VersionConstraint: "< 4.14.246-187.474.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3653",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-3656",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-3732",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"4.14.246-187.474.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALAS-2021-1704",
+					PackageName:       "kernel",
+					VersionConstraint: "< 4.14.246-187.474.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3653",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-3656",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-3732",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"4.14.246-187.474.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.4-2022-007",
+					PackageName:       "kernel-headers",
+					VersionConstraint: ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.4.144-69.257.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.4-2022-007",
+					PackageName:       "kernel",
+					VersionConstraint: ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.4.144-69.257.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.10-2022-005",
+					PackageName:       "kernel-headers",
+					VersionConstraint: ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.10.62-55.141.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.10-2022-005",
+					PackageName:       "kernel",
+					VersionConstraint: ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.10.62-55.141.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -590,7 +731,7 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 
 			entries, err := unmarshal.OSVulnerabilityEntries(f)
 			assert.NoError(t, err)
-			assert.Len(t, entries, len(test.vulns))
+			assert.Len(t, entries, test.numEntries)
 
 			var vulns []grypeDB.Vulnerability
 			for _, entry := range entries {

--- a/pkg/process/v5/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
+++ b/pkg/process/v5/transformers/os/test-fixtures/amazon-multiple-kernel-advisories.json
@@ -1,0 +1,104 @@
+[
+  {
+    "Vulnerability": {
+      "Name": "ALAS-2021-1704",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3653"
+          },
+          {
+            "Name": "CVE-2021-3656"
+          },
+          {
+            "Name": "CVE-2021-3732"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALAS-2021-1704.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "4.14.246-187.474.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.4-2022-007",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.4-2022-007.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.4.144-69.257.amzn2"
+        }
+      ]
+    }
+  },
+  {
+    "Vulnerability": {
+      "Name": "ALASKERNEL-5.10-2022-005",
+      "NamespaceName": "amzn:2",
+      "Description": "",
+      "Severity": "Medium",
+      "Metadata": {
+        "CVE": [
+          {
+            "Name": "CVE-2021-3753"
+          },
+          {
+            "Name": "CVE-2021-40490"
+          }
+        ]
+      },
+      "Link": "https://alas.aws.amazon.com/AL2/ALASKERNEL-5.10-2022-005.html",
+      "FixedIn": [
+        {
+          "Name": "kernel-headers",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        },
+        {
+          "Name": "kernel",
+          "NamespaceName": "amzn:2",
+          "VersionFormat": "rpm",
+          "Version": "5.10.62-55.141.amzn2"
+        }
+      ]
+    }
+  }
+]

--- a/pkg/process/v5/transformers/os/test-fixtures/amzn.json
+++ b/pkg/process/v5/transformers/os/test-fixtures/amzn.json
@@ -37,7 +37,9 @@
       "Link": "https://alas.aws.amazon.com/AL2/ALAS-2018-1106.html",
       "Metadata": {
         "CVE": [
-          {"Name": "CVE-2018-14648"}
+          {
+            "Name": "CVE-2018-14648"
+          }
         ]
       },
       "Name": "ALAS-2018-1106",

--- a/pkg/process/v5/transformers/os/transform.go
+++ b/pkg/process/v5/transformers/os/transform.go
@@ -77,7 +77,7 @@ func Transform(vulnerability unmarshal.OSVulnerability) ([]data.Entry, error) {
 		allVulns = append(allVulns, grypeDB.Vulnerability{
 			ID:                     vulnerability.Vulnerability.Name,
 			PackageQualifiers:      qualifiers,
-			VersionConstraint:      enforceConstraint(fixedInEntry.Version, fixedInEntry.VersionFormat),
+			VersionConstraint:      enforceConstraint(fixedInEntry.Version, fixedInEntry.VersionFormat, vulnerability.Vulnerability.Name),
 			VersionFormat:          fixedInEntry.VersionFormat,
 			PackageName:            grypeNamespace.Resolver().Normalize(fixedInEntry.Name),
 			Namespace:              entryNamespace,
@@ -187,7 +187,28 @@ func getRelatedVulnerabilities(entry unmarshal.OSVulnerability) (vulns []grypeDB
 	return vulns
 }
 
-func enforceConstraint(constraint, format string) string {
+func deriveConstraintFromFix(fixVersion, vulnerabilityID string) string {
+	constraint := fmt.Sprintf("< %s", fixVersion)
+
+	if strings.HasPrefix(vulnerabilityID, "ALASKERNEL-") {
+		// Amazon advisories of the form ALASKERNEL-5.4-2023-048 should be interpreted as only applying to
+		// the 5.4.x kernel line since Amazon issue a separate advisory per affected line, thus the constraint
+		// should be >= 5.4, < {fix version}.  In the future the vunnel schema for OS vulns should be enhanced
+		// to emit actual constraints rather than fixed-in entries (tracked in https://github.com/anchore/vunnel/issues/266)
+		// at which point this workaround in grype-db can be removed.
+
+		components := strings.Split(vulnerabilityID, "-")
+
+		if len(components) == 4 {
+			base := components[1]
+			constraint = fmt.Sprintf(">= %s, < %s", base, fixVersion)
+		}
+	}
+
+	return constraint
+}
+
+func enforceConstraint(constraint, format, vulnerabilityID string) string {
 	constraint = common.CleanConstraint(constraint)
 	if len(constraint) == 0 {
 		return ""
@@ -197,6 +218,6 @@ func enforceConstraint(constraint, format string) string {
 		return common.EnforceSemVerConstraint(constraint)
 	default:
 		// the passed constraint is a fixed version
-		return fmt.Sprintf("< %s", constraint)
+		return deriveConstraintFromFix(constraint, vulnerabilityID)
 	}
 }

--- a/pkg/process/v5/transformers/os/transform_test.go
+++ b/pkg/process/v5/transformers/os/transform_test.go
@@ -674,6 +674,147 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "Amazon",
+			numEntries: 3,
+			fixture:    "test-fixtures/amazon-multiple-kernel-advisories.json",
+			vulns: []grypeDB.Vulnerability{
+				{
+					ID:                "ALAS-2021-1704",
+					PackageName:       "kernel-headers",
+					VersionConstraint: "< 4.14.246-187.474.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3653",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-3656",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-3732",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"4.14.246-187.474.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALAS-2021-1704",
+					PackageName:       "kernel",
+					VersionConstraint: "< 4.14.246-187.474.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3653",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-3656",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-3732",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"4.14.246-187.474.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.4-2022-007",
+					PackageName:       "kernel-headers",
+					VersionConstraint: ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.4.144-69.257.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.4-2022-007",
+					PackageName:       "kernel",
+					VersionConstraint: ">= 5.4, < 5.4.144-69.257.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.4.144-69.257.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.10-2022-005",
+					PackageName:       "kernel-headers",
+					VersionConstraint: ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.10.62-55.141.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+				{
+					ID:                "ALASKERNEL-5.10-2022-005",
+					PackageName:       "kernel",
+					VersionConstraint: ">= 5.10, < 5.10.62-55.141.amzn2",
+					VersionFormat:     "rpm",
+					Namespace:         "amazon:distro:amazonlinux:2",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2021-3753",
+							Namespace: "nvd:cpe",
+						},
+						{
+							ID:        "CVE-2021-40490",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"5.10.62-55.141.amzn2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -686,7 +827,7 @@ func TestParseVulnerabilitiesAllEntries(t *testing.T) {
 
 			entries, err := unmarshal.OSVulnerabilityEntries(f)
 			assert.NoError(t, err)
-			assert.Len(t, entries, len(test.vulns))
+			assert.Len(t, entries, test.numEntries)
 
 			var vulns []grypeDB.Vulnerability
 			for _, entry := range entries {


### PR DESCRIPTION
Fixes https://github.com/anchore/vunnel/issues/265

Before:
```
grype docker.io/anchore/test_images:vulnerabilities-amazonlinux-2-5c26ce9@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa  | grep kernel-headers
 ✔ Parsed image                                                                                                                sha256:58073b915bd374c893f64b52d0bac8635006f6816e8b4c296c4e7d01dd11bdf2
 ✔ Cataloged packages              [285 packages]
 ✔ Scanned for vulnerabilities     [401 vulnerabilities]
   ├── 13 critical, 170 high, 197 medium, 21 low, 0 negligible
   └── 360 fixed
kernel-headers                 4.14.275-207.503.amzn2       5.4.250-166.369.amzn2      rpm           ALASKERNEL-5.4-2023-050   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.249-163.359.amzn2      rpm           ALASKERNEL-5.4-2023-049   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.247-162.350.amzn2      rpm           ALASKERNEL-5.4-2023-048   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.247-161.349.amzn2      rpm           ALASKERNEL-5.4-2023-047   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.242-156.349.amzn2      rpm           ALASKERNEL-5.4-2023-046   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.241-150.347.amzn2      rpm           ALASKERNEL-5.4-2023-044   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.235-144.344.amzn2      rpm           ALASKERNEL-5.4-2023-043   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.231-137.341.amzn2      rpm           ALASKERNEL-5.4-2023-042   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.228-131.415.amzn2      rpm           ALASKERNEL-5.4-2023-041   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.224-128.414.amzn2      rpm           ALASKERNEL-5.4-2022-039   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.219-126.410.amzn2      rpm           ALASKERNEL-5.4-2022-038   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.217-126.408.amzn2      rpm           ALASKERNEL-5.4-2022-037   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.214-120.368.amzn2      rpm           ALASKERNEL-5.4-2022-036   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.209-116.367.amzn2      rpm           ALASKERNEL-5.4-2022-035   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.209-116.363.amzn2      rpm           ALASKERNEL-5.4-2022-034   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.204-113.362.amzn2      rpm           ALASKERNEL-5.4-2022-033   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.201-111.359.amzn2      rpm           ALASKERNEL-5.4-2022-028   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.196-108.356.amzn2      rpm           ALASKERNEL-5.4-2022-026   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.188-104.359.amzn2      rpm           ALASKERNEL-5.4-2022-025   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.186-102.354.amzn2      rpm           ALASKERNEL-5.4-2022-024   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.181-99.354.amzn2       rpm           ALASKERNEL-5.4-2022-023   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.176-91.338.amzn2       rpm           ALASKERNEL-5.4-2022-022   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.172-90.336.amzn2       rpm           ALASKERNEL-5.4-2022-021   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.95-42.163.amzn2        rpm           ALASKERNEL-5.4-2022-020   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.91-41.139.amzn2        rpm           ALASKERNEL-5.4-2022-019   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.80-40.140.amzn2        rpm           ALASKERNEL-5.4-2022-018   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.74-36.135.amzn2        rpm           ALASKERNEL-5.4-2022-017   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.68-34.125.amzn2        rpm           ALASKERNEL-5.4-2022-016   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.58-32.125.amzn2        rpm           ALASKERNEL-5.4-2022-015   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.50-25.83.amzn2         rpm           ALASKERNEL-5.4-2022-013   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.46-19.75.amzn2         rpm           ALASKERNEL-5.4-2022-012   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.38-17.76.amzn2         rpm           ALASKERNEL-5.4-2022-011   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.144-69.257.amzn2       rpm           ALASKERNEL-5.4-2022-008   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.141-67.229.amzn2       rpm           ALASKERNEL-5.4-2022-006   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.129-63.229.amzn2       rpm           ALASKERNEL-5.4-2022-005   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.129-62.227.amzn2       rpm           ALASKERNEL-5.4-2022-004   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.117-58.216.amzn2       rpm           ALASKERNEL-5.4-2022-003   High
kernel-headers                 4.14.275-207.503.amzn2       5.4.105-48.177.amzn2       rpm           ALASKERNEL-5.4-2022-001   High
kernel-headers                 4.14.275-207.503.amzn2       5.15.122-77.145.amzn2      rpm           ALASKERNEL-5.15-2023-025  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.120-74.144.amzn2      rpm           ALASKERNEL-5.15-2023-024  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.43-20.103.amzn2       rpm           ALASKERNEL-5.15-2023-023  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.117-73.143.amzn2      rpm           ALASKERNEL-5.15-2023-022  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.117-72.142.amzn2      rpm           ALASKERNEL-5.15-2023-021  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.110-70.143.amzn2      rpm           ALASKERNEL-5.15-2023-020  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.104-63.140.amzn2      rpm           ALASKERNEL-5.15-2023-019  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.108-65.141.amzn2      rpm           ALASKERNEL-5.15-2023-017  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.106-64.140.amzn2      rpm           ALASKERNEL-5.15-2023-016  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.102-61.139.amzn2      rpm           ALASKERNEL-5.15-2023-015  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.90-54.138.amzn2       rpm           ALASKERNEL-5.15-2023-013  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.86-53.137.amzn2       rpm           ALASKERNEL-5.15-2023-012  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.79-51.138.amzn2       rpm           ALASKERNEL-5.15-2022-011  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.73-48.135.amzn2       rpm           ALASKERNEL-5.15-2022-009  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.69-37.134.amzn2       rpm           ALASKERNEL-5.15-2022-008  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.54-25.126.amzn2       rpm           ALASKERNEL-5.15-2022-005  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.50-23.125.amzn2       rpm           ALASKERNEL-5.15-2022-002  High
kernel-headers                 4.14.275-207.503.amzn2       5.15.43-20.123.amzn2       rpm           ALASKERNEL-5.15-2022-001  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.186-179.751.amzn2     rpm           ALASKERNEL-5.10-2023-038  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.184-175.749.amzn2     rpm           ALASKERNEL-5.10-2023-037  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.112-108.499.amzn2     rpm           ALASKERNEL-5.10-2023-036  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.184-175.731.amzn2     rpm           ALASKERNEL-5.10-2023-035  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.184-174.730.amzn2     rpm           ALASKERNEL-5.10-2023-034  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.179-168.710.amzn2     rpm           ALASKERNEL-5.10-2023-033  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.178-162.673.amzn2     rpm           ALASKERNEL-5.10-2023-031  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.177-158.645.amzn2     rpm           ALASKERNEL-5.10-2023-029  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.173-154.642.amzn2     rpm           ALASKERNEL-5.10-2023-028  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.165-143.735.amzn2     rpm           ALASKERNEL-5.10-2023-026  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.162-141.675.amzn2     rpm           ALASKERNEL-5.10-2023-025  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.157-139.675.amzn2     rpm           ALASKERNEL-5.10-2022-024  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.155-138.670.amzn2     rpm           ALASKERNEL-5.10-2022-023  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.149-133.644.amzn2     rpm           ALASKERNEL-5.10-2022-022  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.147-133.644.amzn2     rpm           ALASKERNEL-5.10-2022-021  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.144-127.601.amzn2     rpm           ALASKERNEL-5.10-2022-020  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.130-118.517.amzn2     rpm           ALASKERNEL-5.10-2022-018  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.126-117.518.amzn2     rpm           ALASKERNEL-5.10-2022-015  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.118-111.515.amzn2     rpm           ALASKERNEL-5.10-2022-014  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.109-104.500.amzn2     rpm           ALASKERNEL-5.10-2022-013  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.106-102.504.amzn2     rpm           ALASKERNEL-5.10-2022-012  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.102-99.473.amzn2      rpm           ALASKERNEL-5.10-2022-011  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.96-90.460.amzn2       rpm           ALASKERNEL-5.10-2022-010  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.93-87.444.amzn2       rpm           ALASKERNEL-5.10-2022-009  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.75-79.358.amzn2       rpm           ALASKERNEL-5.10-2022-007  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.68-62.173.amzn2       rpm           ALASKERNEL-5.10-2022-006  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.59-52.142.amzn2       rpm           ALASKERNEL-5.10-2022-004  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.50-44.132.amzn2       rpm           ALASKERNEL-5.10-2022-003  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.47-39.130.amzn2       rpm           ALASKERNEL-5.10-2022-002  High
kernel-headers                 4.14.275-207.503.amzn2       5.10.35-31.135.amzn2       rpm           ALASKERNEL-5.10-2022-001  High
kernel-headers                 4.14.275-207.503.amzn2       4.14.320-243.544.amzn2     rpm           ALAS-2023-2179            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.320-242.534.amzn2     rpm           ALAS-2023-2130            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.318-241.531.amzn2     rpm           ALAS-2023-2108            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.318-240.529.amzn2     rpm           ALAS-2023-2100            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.314-238.539.amzn2     rpm           ALAS-2023-2050            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.313-235.533.amzn2     rpm           ALAS-2023-2027            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.309-231.529.amzn2     rpm           ALAS-2023-1987            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.304-226.531.amzn2     rpm           ALAS-2023-1932            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.301-224.520.amzn2     rpm           ALAS-2022-1903            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.299-223.520.amzn2     rpm           ALAS-2022-1888            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.296-222.539.amzn2     rpm           ALAS-2022-1876            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.294-220.533.amzn2     rpm           ALAS-2022-1852            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.291-218.527.amzn2     rpm           ALAS-2022-1838            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.287-215.504.amzn2     rpm           ALAS-2022-1825            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.285-215.501.amzn2     rpm           ALAS-2022-1813            High
kernel-headers                 4.14.275-207.503.amzn2       4.14.281-212.502.amzn2     rpm           ALAS-2022-1798            High
kernel-headers                 4.14.275-207.503.amzn2       5.4.253-167.359.amzn2      rpm           ALASKERNEL-5.4-2023-051   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.242-155.348.amzn2      rpm           ALASKERNEL-5.4-2023-045   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.226-129.415.amzn2      rpm           ALASKERNEL-5.4-2022-040   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.156-83.273.amzn2       rpm           ALASKERNEL-5.4-2022-031   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.156-83.273.amzn2       rpm           ALASKERNEL-5.4-2022-029   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.156-83.273.amzn2       rpm           ALASKERNEL-5.4-2022-027   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.58-27.104.amzn2        rpm           ALASKERNEL-5.4-2022-014   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.162-86.275.amzn2       rpm           ALASKERNEL-5.4-2022-010   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.156-83.273.amzn2       rpm           ALASKERNEL-5.4-2022-009   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.144-69.257.amzn2       rpm           ALASKERNEL-5.4-2022-007   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.4.110-54.182.amzn2       rpm           ALASKERNEL-5.4-2022-002   Medium
kernel-headers                 4.14.275-207.503.amzn2       5.15.110-70.141.amzn2      rpm           ALASKERNEL-5.15-2023-018  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.15.93-55.139.amzn2       rpm           ALASKERNEL-5.15-2023-014  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.15.75-48.135.amzn2       rpm           ALASKERNEL-5.15-2022-010  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.15.59-33.133.amzn2       rpm           ALASKERNEL-5.15-2022-007  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.15.57-29.131.amzn2       rpm           ALASKERNEL-5.15-2022-006  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.10.179-166.674.amzn2     rpm           ALASKERNEL-5.10-2023-032  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.10.29-27.126.amzn2       rpm           ALASKERNEL-5.10-2023-030  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.10.167-147.601.amzn2     rpm           ALASKERNEL-5.10-2023-027  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.10.135-122.509.amzn2     rpm           ALASKERNEL-5.10-2022-019  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.10.82-83.359.amzn2       rpm           ALASKERNEL-5.10-2022-008  Medium
kernel-headers                 4.14.275-207.503.amzn2       5.10.62-55.141.amzn2       rpm           ALASKERNEL-5.10-2022-005  Medium
kernel-headers                 4.14.275-207.503.amzn2       4.14.322-244.536.amzn2     rpm           ALAS-2023-2206            Medium
kernel-headers                 4.14.275-207.503.amzn2       4.14.314-237.533.amzn2     rpm           ALAS-2023-2035            Medium
kernel-headers                 4.14.275-207.503.amzn2       4.14.290-217.505.amzn2     rpm           ALAS-2022-1833            Medium
kernel-headers                 4.14.275-207.503.amzn2       4.14.276-211.499.amzn2     rpm           ALAS-2022-1793            Medium
```

After:
```
grype docker.io/anchore/test_images:vulnerabilities-amazonlinux-2-5c26ce9@sha256:cf742eca189b02902a0a7926ac3fbb423e799937bf4358b0d2acc6cc36ab82aa  | grep kernel-headers
 ✔ Parsed image                                                                                                                sha256:58073b915bd374c893f64b52d0bac8635006f6816e8b4c296c4e7d01dd11bdf2
 ✔ Cataloged packages              [285 packages]
 ✔ Scanned for vulnerabilities     [289 vulnerabilities]
   ├── 13 critical, 84 high, 171 medium, 21 low, 0 negligible
   └── 248 fixed
kernel-headers                 4.14.275-207.503.amzn2       4.14.320-243.544.amzn2     rpm           ALAS-2023-2179       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.320-242.534.amzn2     rpm           ALAS-2023-2130       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.318-241.531.amzn2     rpm           ALAS-2023-2108       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.318-240.529.amzn2     rpm           ALAS-2023-2100       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.314-238.539.amzn2     rpm           ALAS-2023-2050       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.313-235.533.amzn2     rpm           ALAS-2023-2027       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.309-231.529.amzn2     rpm           ALAS-2023-1987       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.304-226.531.amzn2     rpm           ALAS-2023-1932       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.301-224.520.amzn2     rpm           ALAS-2022-1903       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.299-223.520.amzn2     rpm           ALAS-2022-1888       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.296-222.539.amzn2     rpm           ALAS-2022-1876       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.294-220.533.amzn2     rpm           ALAS-2022-1852       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.291-218.527.amzn2     rpm           ALAS-2022-1838       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.287-215.504.amzn2     rpm           ALAS-2022-1825       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.285-215.501.amzn2     rpm           ALAS-2022-1813       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.281-212.502.amzn2     rpm           ALAS-2022-1798       High
kernel-headers                 4.14.275-207.503.amzn2       4.14.314-237.533.amzn2     rpm           ALAS-2023-2035       Medium
kernel-headers                 4.14.275-207.503.amzn2       4.14.290-217.505.amzn2     rpm           ALAS-2022-1833       Medium
kernel-headers                 4.14.275-207.503.amzn2       4.14.276-211.499.amzn2     rpm           ALAS-2022-1793       Medium
```