### PR TITLE
Add yardstick labels symlink to gitignore

### DIFF
--- a/.github/workflows/daily-db-publisher.yaml
+++ b/.github/workflows/daily-db-publisher.yaml
@@ -21,6 +21,7 @@ on:
 env:
   CGO_ENABLED: "0"
   SLACK_NOTIFICATIONS: true
+  FORCE_COLOR: true
 
 jobs:
   discover-schema-versions:
@@ -85,7 +86,7 @@ jobs:
               -c ./config/grype-db-manager/publish-production.yaml \
               db build-and-upload \
                 --schema-version ${{ matrix.schema-version }} \
-                -vv
+                -vvv
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/staging-db-publisher.yaml
+++ b/.github/workflows/staging-db-publisher.yaml
@@ -41,6 +41,7 @@ env:
   # note: these GRYPE_* env vars are used by the python scripts
   GRYPE_DB_MANAGER_VALIDATE_LISTING_OVERRIDE_DB_SCHEMA_VERSION: ${{ github.event.inputs.schema-version }}
   GRYPE_DB_MANAGER_VALIDATE_LISTING_OVERRIDE_GRYPE_VERSION: ${{ github.event.inputs.grype-branch }}
+  FORCE_COLOR: true
 
 jobs:
   publish-staging-db:
@@ -91,7 +92,7 @@ jobs:
               -c ./config/grype-db-manager/publish-staging.yaml \
                 db build-and-upload \
                   --schema-version ${{ github.event.inputs.schema-version }} \
-                  -vv
+                  -vvv
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -10,6 +10,7 @@ on:
 
 env:
   CGO_ENABLED: "0"
+  FORCE_COLOR: true
 
 jobs:
 

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -10,7 +10,6 @@ on:
 
 env:
   CGO_ENABLED: "0"
-  FORCE_COLOR: true
 
 jobs:
 
@@ -135,6 +134,8 @@ jobs:
 
       - name: Build and validate the DB
         run: make db-acceptance schema=${{ matrix.schema-version }}
+        env:
+          FORCE_COLOR: true
 
 
   Cli-Go-Linux:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-/data
+# note: you cannot add exceptions for nested paths. You have to add patterns for each parent path as a pattern and specific exceptions for those parents
+# this dance here is to ignore everything in /data but still include the symlink at /data/yardstick/labels
+/data/*
+!/data/yardstick
+/data/yardstick/*
 !/data/yardstick/labels
 !/data/vulnerability-match-labels
+
+# default data directories
 /vunnel
 /bin
 .yardstick

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "data/vulnerability-match-labels"]
 	path = data/vulnerability-match-labels
 	url = git@github.com:anchore/vulnerability-match-labels.git
+	branch = main

--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -17,7 +17,7 @@ db:
 
     # float between 0 and 100, the maximum % of unlabeled matches for a scan result before the gate fails (default 10%,
     # meaning the test scan must have less than 10% unlabeled matches to pass the gate)
-    unlabeled-matches-threshold: 25.0
+    unlabeled-matches-threshold: 35.0
 
     # integer, the maximum allowable introduced FNs by the test scan (but found by the OSS scan) before the gate fails
     # (default 0, meaning the test scan must have the same or fewer FNs than the OSS scan to pass the gate)

--- a/data/yardstick/labels
+++ b/data/yardstick/labels
@@ -1,0 +1,1 @@
+../vulnerability-match-labels/labels

--- a/test/db/acceptance.sh
+++ b/test/db/acceptance.sh
@@ -26,4 +26,4 @@ fi
 
 title "Validating DB"
 
-grype-db-manager db validate $DB_ID -vv
+grype-db-manager db validate $DB_ID -vvv


### PR DESCRIPTION
A few changes were made in this PR:
- [x] while troubleshooting it would have been nice to see a little more information in the output, so verbosity has been increased
- [x] similarly, there is nice formatting that is disabled due to the environment, so I've forced it to be enabled
- [x] the labels should never be behind or we risk not building a DB due to stale labels. I've updated the git submodule to track the main branch of the vulnerability-match-labels repo. If ever there is an issue in the future, we can pin back to a specific version.
- [x] the .gitignore was incorrectly ignoring the data/yardstick/labels directory. This has been corrected.
- [x] bumped the unlabeled matches gate from 25% to 35% as a workaround for v1 and v2 rpm epoch issues.

_More on the gitignore change..._

This is not valid:

```
# .gitignore
/data
!/data/yardstick/labels
```

Tip of the hat to https://stackoverflow.com/questions/3203228/git-ignore-exception/72380673#72380673 on this one.

When running the production run yesterday there were no relative comparison differences so the labels were not used. However, today there happened to be differences, so the labels were attempted to be used, but the link was not checked in, so it was as if there were no labels. The gate (correctly) failed since there were too many matches that were unlabeled.
