### PR TITLE
Workaround v1 and v2 schema differences

### DIFF
--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -17,7 +17,8 @@ db:
 
     # float between 0 and 100, the maximum % of unlabeled matches for a scan result before the gate fails (default 10%,
     # meaning the test scan must have less than 10% unlabeled matches to pass the gate)
-    unlabeled-matches-threshold: 35.0
+    # TODO: this should be at 25.0 after we sunset v1 and v2 schemas
+    unlabeled-matches-threshold: 50.0
 
     # integer, the maximum allowable introduced FNs by the test scan (but found by the OSS scan) before the gate fails
     # (default 0, meaning the test scan must have the same or fewer FNs than the OSS scan to pass the gate)


### PR DESCRIPTION
The v1 and v2 schemas can only use grype versions that don't have epoch values on RPM package versions, which means that labels cannot be correctly applied. This means that any RHEL based image tends to easily cross the unlabeled matches threshold. I'll work on sunsetting the v1 and v2 schemas, but in the meantime to get DBs built again I've bumped this threshold.