### PR TITLE
chore: bump crane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GOSIMPORTS_VERSION := v0.3.7
 BOUNCER_VERSION = v0.4.0
 CHRONICLE_VERSION = v0.6.0
 GORELEASER_VERSION = v1.13.0
-CRANE_VERSION=v0.12.1
+CRANE_VERSION=v0.16.1
 GLOW_VERSION := v1.5.0
 
 # Formatting variables #################################


### PR DESCRIPTION
Recent versions of Go get an import error on "make bootstrap" with the version of crane previously used.

Before:
```
$ make bootstrap
... snip ...
GOBIN="/Users/willmurphy/work/grype-db/.tmp" go install github.com/google/go-containerregistry/cmd/crane@v0.12.1
# golang.org/x/sys/unix
../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/ioctl.go:11:2: "os" imported and not used
make: *** [bootstrap-tools] Error 1
```

After: `make bootstrap` succeeds