### PR TITLE
Upload DBs to s3 with ContentType header

### DIFF
--- a/manager/src/grype_db_manager/cli/db.py
+++ b/manager/src/grype_db_manager/cli/db.py
@@ -188,7 +188,7 @@ def upload_db(cfg: config.Application, db_uuid: str, ttl_seconds: int) -> None:
         key=key,
         path=db_info.archive_path,
         CacheControl=f"public,max-age={ttl_seconds}",
-        **kwargs
+        **kwargs,
     )
 
     click.echo(f"DB {db_uuid!r} uploaded to s3://{s3_bucket}/{s3_path}")

--- a/manager/src/grype_db_manager/cli/db.py
+++ b/manager/src/grype_db_manager/cli/db.py
@@ -178,11 +178,17 @@ def upload_db(cfg: config.Application, db_uuid: str, ttl_seconds: int) -> None:
 
     key = f"{s3_path}/{os.path.basename(db_info.archive_path)}"
 
+    # TODO: we have folks that require legacy behavior, where the content type was application/x-tar
+    kwargs = {}
+    if db_info.archive_path.endswith(".tar.gz"):
+        kwargs["ContentType"] = "application/x-tar"
+
     s3utils.upload_file(
         bucket=s3_bucket,
         key=key,
         path=db_info.archive_path,
         CacheControl=f"public,max-age={ttl_seconds}",
+        **kwargs
     )
 
     click.echo(f"DB {db_uuid!r} uploaded to s3://{s3_bucket}/{s3_path}")

--- a/manager/src/grype_db_manager/s3utils.py
+++ b/manager/src/grype_db_manager/s3utils.py
@@ -4,11 +4,15 @@ import logging
 from typing import TYPE_CHECKING
 
 import boto3
+import magic
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from botocore.client import BaseClient
+
+
+mime = magic.Magic(mime=True)
 
 
 class ClientFactory:
@@ -71,6 +75,11 @@ def upload(bucket: str, key: str, contents: str, client_factory: type[ClientFact
 
 def upload_file(bucket: str, key: str, path: str, client_factory: type[ClientFactory] = ClientFactory, **kwargs) -> None:
     logging.debug(f"uploading file={path} to s3 bucket={bucket} key={key}")
+
+    if "ContentType" not in kwargs:
+        content_type = mime.from_file(path)
+        if content_type:
+            kwargs["ContentType"] = content_type
 
     # boto is a little too verbose... let's tone that down just for a bit
     with LoggingContext(level=logging.WARNING):

--- a/manager/tests/unit/cli/test_db.py
+++ b/manager/tests/unit/cli/test_db.py
@@ -34,4 +34,5 @@ def test_upload_db(mocker, test_dir_path, redact_aws_credentials):
         bucket="testbucket",
         key="grype/databases/archive.tar.gz",
         CacheControl="public,max-age=31536000",
+        ContentType="application/x-tar",  # this is legacy behavior, remove me
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1399,6 +1399,17 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-magic"
+version = "0.4.27"
+description = "File type identification using libmagic"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"},
+    {file = "python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -2124,4 +2135,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<=3.13"
-content-hash = "011726039e054f1f86fbf894deeb03889bcaddfc3e9c05fe1ced1a085870466e"
+content-hash = "1faf17e63a9c58f3f6549d6b345993cdf0cbb0851ab563fb539086bbc95948d4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ pyyaml = ">=5.0.1, <7"
 colr = "^0.9.1"
 supports-color = "^0.1.2"
 pyyaml-include = "^1.3.1"
+python-magic = "^0.4.27"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=23.7.0, <24"


### PR DESCRIPTION
Previously we had been uploading DBs with the S3 CLI which had been inferring a mime type from any file it would upload and including the `ContentType` header. Once we moved to using boto3 this wasn't being done (we need to do it ourselves) -- this PR adds this functionality back.