### PR TITLE
chore: pin vunnel to v0.16.0

### DIFF
--- a/config/grype-db/publish-nightly.yaml
+++ b/config/grype-db/publish-nightly.yaml
@@ -13,7 +13,7 @@ provider:
 
   vunnel:
     executor: docker
-    docker-tag: latest
+    docker-tag: v0.16.0
     generate-configs: true
     env:
       GITHUB_TOKEN: $GITHUB_TOKEN


### PR DESCRIPTION
Vunnel v0.17.0 is broken and should not be used.  Pinning back to v0.16.0 until we can sort it out and cut a new release.