### PR TITLE
Revert "chore: pin vunnel to v0.16.0"

### DIFF
--- a/config/grype-db/publish-nightly.yaml
+++ b/config/grype-db/publish-nightly.yaml
@@ -13,7 +13,7 @@ provider:
 
   vunnel:
     executor: docker
-    docker-tag: v0.16.0
+    docker-tag: latest
     generate-configs: true
     env:
       GITHUB_TOKEN: $GITHUB_TOKEN


### PR DESCRIPTION
Reverts anchore/grype-db#177 now that we have fixed the regression upstream in vunnel