### PR TITLE
Add basic namespace check on publishing DBs

### DIFF
--- a/manager/src/grype_db_manager/cli/db.py
+++ b/manager/src/grype_db_manager/cli/db.py
@@ -92,10 +92,22 @@ def show_db(cfg: config.Application, db_uuid: str) -> None:
 )
 @click.option("--verbose", "-v", "verbosity", count=True, help="show details of all comparisons")
 @click.option("--recapture", "-r", is_flag=True, help="recapture grype results (even if not stale)")
-@click.option("--skip-namespace-check", "skip_namespace_check", is_flag=True, help="do not ensure the minimum expected namespaces are present")
+@click.option(
+    "--skip-namespace-check",
+    "skip_namespace_check",
+    is_flag=True,
+    help="do not ensure the minimum expected namespaces are present",
+)
 @click.argument("db-uuid")
 @click.pass_obj
-def validate_db(cfg: config.Application, db_uuid: str, images: list[str], verbosity: int, recapture: bool, skip_namespace_check: bool) -> None:
+def validate_db(
+    cfg: config.Application,
+    db_uuid: str,
+    images: list[str],
+    verbosity: int,
+    recapture: bool,
+    skip_namespace_check: bool,
+) -> None:
     logging.info(f"validating DB {db_uuid}")
 
     if not images:
@@ -203,6 +215,12 @@ def upload_db(cfg: config.Application, db_uuid: str, ttl_seconds: int) -> None:
 @click.option("--schema-version", "-s", required=True, help="the DB schema version to build, validate, and upload")
 @click.option("--dry-run", "-d", is_flag=True, help="do not upload the DB to S3")
 @click.option("--skip-validate", is_flag=True, help="skip validation of the DB")
+@click.option(
+    "--skip-namespace-check",
+    "skip_namespace_check",
+    is_flag=True,
+    help="do not ensure the minimum expected namespaces are present",
+)
 @click.option("--verbose", "-v", "verbosity", count=True, help="show details of all comparisons")
 @click.pass_obj
 @click.pass_context
@@ -212,6 +230,7 @@ def build_and_upload_db(
     cfg: config.Application,
     schema_version: str,
     skip_validate: bool,
+    skip_namespace_check: bool,
     dry_run: bool,
     verbosity: bool,
 ) -> None:
@@ -227,7 +246,7 @@ def build_and_upload_db(
         click.echo(f"{Format.ITALIC}Skipping validation of DB {db_uuid!r}{Format.RESET}")
     else:
         click.echo(f"{Format.BOLD}Validating DB {db_uuid!r}{Format.RESET}")
-        ctx.invoke(validate_db, db_uuid=db_uuid, verbosity=verbosity)
+        ctx.invoke(validate_db, db_uuid=db_uuid, verbosity=verbosity, skip_namespace_check=skip_namespace_check)
 
     if not dry_run:
         click.echo(f"{Format.BOLD}Uploading DB {db_uuid!r}{Format.RESET}")

--- a/manager/src/grype_db_manager/cli/db.py
+++ b/manager/src/grype_db_manager/cli/db.py
@@ -92,9 +92,10 @@ def show_db(cfg: config.Application, db_uuid: str) -> None:
 )
 @click.option("--verbose", "-v", "verbosity", count=True, help="show details of all comparisons")
 @click.option("--recapture", "-r", is_flag=True, help="recapture grype results (even if not stale)")
+@click.option("--skip-namespace-check", "skip_namespace_check", is_flag=True, help="do not ensure the minimum expected namespaces are present")
 @click.argument("db-uuid")
 @click.pass_obj
-def validate_db(cfg: config.Application, db_uuid: str, images: list[str], verbosity: int, recapture: bool) -> None:
+def validate_db(cfg: config.Application, db_uuid: str, images: list[str], verbosity: int, recapture: bool, skip_namespace_check: bool) -> None:
     logging.info(f"validating DB {db_uuid}")
 
     if not images:
@@ -106,6 +107,10 @@ def validate_db(cfg: config.Application, db_uuid: str, images: list[str], verbos
     if not db_info:
         click.echo(f"no database found with session id {db_uuid}")
         return
+
+    if not skip_namespace_check:
+        # ensure the minimum number of namespaces are present
+        db_manager.validate_namespaces(db_uuid=db_uuid)
 
     # resolve tool versions and install them
     yardstick.store.config.set_values(store_root=cfg.data.yardstick_root)

--- a/manager/tests/cli/workflow-2-validate-db.sh
+++ b/manager/tests/cli/workflow-2-validate-db.sh
@@ -20,12 +20,12 @@ header "Case 1: fail DB validation (too many unknowns)"
 
 make clean-yardstick-labels
 
-run_expect_fail grype-db-manager db validate $DB_ID -vvv
+run_expect_fail grype-db-manager db validate $DB_ID -vvv --skip-namespace-check
 assert_contains $(last_stderr_file) "current indeterminate matches % is greater than 10.0%"
 
 
 #############################################
-header "Case 2: pass DB validation"
+header "Case 2: fail DB validation (missing namespaces)"
 
 make clean-yardstick-labels
 echo "installing labels"
@@ -33,7 +33,20 @@ echo "installing labels"
 cp -a ../../../data/vulnerability-match-labels/labels/docker.io+oraclelinux* ./cli-test-data/yardstick/labels/
 tree ./cli-test-data/yardstick/labels/
 
-run grype-db-manager db validate $DB_ID -vvv
+run_expect_fail grype-db-manager db validate $DB_ID -vvv
+assert_contains $(last_stderr_file) "missing namespaces in DB"
+
+
+#############################################
+header "Case 3: pass DB validation"
+
+make clean-yardstick-labels
+echo "installing labels"
+# use the real labels
+cp -a ../../../data/vulnerability-match-labels/labels/docker.io+oraclelinux* ./cli-test-data/yardstick/labels/
+tree ./cli-test-data/yardstick/labels/
+
+run grype-db-manager db validate $DB_ID -vvv --skip-namespace-check
 assert_contains $(last_stdout_file) "Validation passed"
 
 

--- a/manager/tests/cli/workflow-4-full-publish.sh
+++ b/manager/tests/cli/workflow-4-full-publish.sh
@@ -42,10 +42,10 @@ header "Case 1: create and publish a DB"
 
 # note: this test is exercising the following commands:
 # grype-db-manager db build
-# grype-db-manager db validate <uuid>
+# grype-db-manager db validate <uuid> --skip-namespace-check
 # grype-db-manager db upload <uuid>
 
-run grype-db-manager db build-and-upload --schema-version $SCHEMA_VERSION
+run grype-db-manager db build-and-upload --schema-version $SCHEMA_VERSION --skip-namespace-check
 assert_contains $(last_stdout_file) "Validation passed"
 assert_contains $(last_stdout_file) "' uploaded to s3://testbucket/grype/databases"
 

--- a/manager/tests/unit/test_grypedb.py
+++ b/manager/tests/unit/test_grypedb.py
@@ -2,6 +2,8 @@ import os
 import datetime
 import pathlib
 
+import pytest
+
 from grype_db_manager import grypedb
 
 
@@ -62,6 +64,49 @@ class TestDBManager:
             v = datetime.datetime.fromisoformat(timestamp)
             assert v
             assert v.year == datetime.datetime.now().year
+
+    @pytest.mark.parametrize(
+        "listed_namespaces, schema_version, expect_error",
+        [
+            pytest.param([], 5, True, id="empty"),
+            pytest.param(["namespace1"], 5, True, id="too few namespaces"),
+            pytest.param(grypedb.expected_namespaces, 5, False, id="v5 matches"),
+            pytest.param(grypedb.expected_namespaces + ["extra_items"], 5, False, id="v5 with extra items"),
+            pytest.param(list(grypedb.expected_namespaces)[:-5], 5, True, id="v5 missing items"),
+            pytest.param(grypedb.v3_expected_namespaces, 3, False, id="v3 matches"),
+            pytest.param(grypedb.v3_expected_namespaces + ["extra_items"], 3, False, id="v3 with extra items"),
+            pytest.param(list(grypedb.v3_expected_namespaces)[:-5], 3, True, id="v3 missing items"),
+        ],
+    )
+    def test_validate_namespaces(self, tmp_path: pathlib.Path, mocker, schema_version, listed_namespaces, expect_error):
+        assert len(grypedb.expected_namespaces) > 0
+
+        dbm = grypedb.DBManager(root_dir=tmp_path.as_posix())
+        session_id = dbm.new_session()
+
+        # patch list_namespaces to return a mock
+        dbm.list_namespaces = mocker.MagicMock()
+        dbm.list_namespaces.return_value = listed_namespaces
+
+        # patch db_info to return a mock
+        dbm.get_db_info = mocker.MagicMock()
+        dbm.get_db_info.return_value = grypedb.DBInfo(
+            uuid="",
+            schema_version=schema_version,
+            db_checksum="",
+            db_created="",
+            data_created="",
+            archive_path="",
+        )
+
+        if expect_error:
+            with pytest.raises(grypedb.DBNamespaceException):
+                dbm.validate_namespaces(session_id)
+        else:
+            dbm.validate_namespaces(session_id)
+
+        dbm.list_namespaces.assert_called_once()
+        dbm.get_db_info.assert_called_once()
 
 
 class TestGrypeDB:


### PR DESCRIPTION
Partially addresses #178

This is an addition to the validation of the DBs being published to ensure they have the minimum expected namespaces based on the current snapshot of namespaces that vunnel provides. 

This is not an ideal implementation, since it hard codes the list of namespaces for each supported schema (4-5, 1-3) and this is already captured for schemas 4-5 with https://github.com/anchore/vunnel/blob/main/tests/quality/config.yaml . The hard part about using this is we need to know the specific vunnel version used to be able to reference the correct yaml file (which, also unfortunately, means this would need to be an online operation). If the vunnel could output at least some of this information that would make a better long term path here.

This PR is not about the long term path, but something we could add today that verifies we're not publishing sub-standard databases.