### PR TITLE
Make schema mapping configurable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "data/vulnerability-match-labels"]
 	path = data/vulnerability-match-labels
-	url = git@github.com:anchore/vulnerability-match-labels.git
+	url = https://github.com/anchore/vulnerability-match-labels.git
 	branch = main

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -46,7 +46,7 @@ format: virtual-env-check  ## Format all code (black)
 
 .PHONY: unit
 unit: virtual-env-check  ## Run unit tests
-	pytest --cov-fail-under=$(COVERAGE_THRESHOLD) --config-file ../pyproject.toml --cov-report html --cov grype_db_manager -v tests/unit/
+	pytest --cov-fail-under=$(COVERAGE_THRESHOLD) --config-file ../pyproject.toml --cov-report html --cov grype_db_manager -vv tests/unit/
 
 .PHONY: cli
 cli: virtual-env-check  ## Run cli tests

--- a/manager/src/grype_db_manager/cli/config.py
+++ b/manager/src/grype_db_manager/cli/config.py
@@ -102,7 +102,7 @@ class Data:
 class Application:
     data: Data = field(default_factory=Data)
     log: Log = field(default_factory=Log)
-
+    schema_mapping_file: str = ""  # default is to use built-in schema mapping
     grype_db: GrypeDB = field(default_factory=GrypeDB)
     validate: Validate = field(default_factory=Validate)
     distribution: Distribution = field(default_factory=Distribution)
@@ -253,6 +253,10 @@ def _load(path: str, wire_values: bool = True, env: Mapping | None = None) -> Ap
         else:
             # in case this is used back-to-back with a grype-db-manager run, reset the region
             s3utils.ClientFactory.set_region_name(None)
+
+        # ensure we're using the correct schema mapping file
+        if cfg.schema_mapping_file:
+            db.schema.register_mapping(cfg.schema_mapping_file)
 
     return cfg
 

--- a/manager/src/grype_db_manager/db/schema.py
+++ b/manager/src/grype_db_manager/db/schema.py
@@ -4,6 +4,7 @@ import json
 from dataclasses import dataclass, field
 from functools import lru_cache
 from importlib.resources import files
+from typing import Any
 
 import mergedeep
 from dataclass_wizard import asdict, fromdict
@@ -37,20 +38,20 @@ class SchemaMapping:
         return supported
 
 
-def register_mapping(file: str):
-    with open(file, "r") as f:
-        global _mapping_file_content
+def register_mapping(file: str) -> None:
+    with open(file) as f:
+        global _mapping_file_content  # noqa: PLW0603
         _mapping_file_content = f.read()
 
 
 @lru_cache
-def _mapping():
-    if _mapping_file_content is None:
-        content = files("grype_db_manager.data").joinpath("schema-info.json").read_text()
-    else:
-        content = _mapping_file_content
+def _mapping() -> dict[str, Any]:
+    content = (
+        files("grype_db_manager.data").joinpath("schema-info.json").read_text()
+        if _mapping_file_content is None
+        else _mapping_file_content
+    )
     return json.loads(content)
-
 
 
 def _load() -> SchemaMapping:

--- a/manager/tests/unit/cli/fixtures/config/full.yaml
+++ b/manager/tests/unit/cli/fixtures/config/full.yaml
@@ -22,6 +22,8 @@ distribution:
   s3-endpoint-url: http://localhost:4566
   download-url-prefix: http://localhost:4566/testbucket
 
+schemaMappingFile: "mapping.json"
+
 validate:
   listing:
     image: "centos:8.2.2004"

--- a/manager/tests/unit/cli/test_config.py
+++ b/manager/tests/unit/cli/test_config.py
@@ -58,6 +58,7 @@ grypeDb:
   version: latest
 log:
   level: INFO
+schemaMappingFile: ''
 validate:
   db:
     defaultMaxYear: 2021
@@ -104,6 +105,7 @@ grypeDb:
   version: file://.
 log:
   level: INFO
+schemaMappingFile: mapping.json
 validate:
   db:
     defaultMaxYear: 2021

--- a/manager/tests/unit/cli/test_listing.py
+++ b/manager/tests/unit/cli/test_listing.py
@@ -137,7 +137,7 @@ def test_create_listing(
     # contains an application config file
     config_dir_path = test_dir_path(f"fixtures/listing/{case_dir}")
     listing_s3_mock(config_dir_path, extra_dbs=extra_dbs)
-    mock_file_age.return_value = 42 # needs to be less than distribution.MAX_DB_AGE
+    mock_file_age.return_value = 42  # needs to be less than distribution.MAX_DB_AGE
 
     with utils.set_directory(config_dir_path):
         with open("expected-listing.json") as f:


### PR DESCRIPTION
The schema mapping file is baked directly into `grype-db-manager`, which means if you want a subselection of the schema versions to be validated when updating a listing file you cannot. This change makes this file be configurable.


Additionally changes the submodule to be `https` not authed over `ssh`.