### PR TITLE
Use latest data timestamp for DB timestamp

### DIFF
--- a/cmd/grype-db/cli/commands/build.go
+++ b/cmd/grype-db/cli/commands/build.go
@@ -86,38 +86,55 @@ func runBuild(cfg buildConfig) error {
 		pvdrs = pvdrs.Filter(cfg.Provider.IncludeFilter...)
 	}
 
-	var states []provider.State
-	stateTimestamp := time.Now()
-	log.Debug("reading all provider state")
-	for _, p := range pvdrs {
-		log.WithFields("provider", p.ID().Name).Debug("reading state")
-
-		sd, err := p.State()
-		if err != nil {
-			return fmt.Errorf("unable to read provider state: %w", err)
-		}
-
-		if !cfg.SkipValidation {
-			log.WithFields("provider", p.ID().Name).Trace("validating state")
-			if err := sd.Verify(); err != nil {
-				return fmt.Errorf("invalid provider state: %w", err)
-			}
-		}
-
-		if sd.Timestamp.Before(stateTimestamp) {
-			stateTimestamp = sd.Timestamp
-		}
-		states = append(states, *sd)
-	}
-
-	if !cfg.SkipValidation {
-		log.Debugf("state validated for all providers")
+	states, err := providerStates(cfg.SkipValidation, pvdrs)
+	if err != nil {
+		return fmt.Errorf("unable to get provider states: %w", err)
 	}
 
 	return process.Build(process.BuildConfig{
 		SchemaVersion: cfg.SchemaVersion,
 		Directory:     cfg.Directory,
 		States:        states,
-		Timestamp:     stateTimestamp,
+		Timestamp:     latestTimestamp(states),
 	})
+}
+
+func providerStates(skipValidation bool, providers []provider.Provider) ([]provider.State, error) {
+	var states []provider.State
+	log.Debug("reading all provider state")
+
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("no providers configured")
+	}
+
+	for _, p := range providers {
+		log.WithFields("provider", p.ID().Name).Debug("reading state")
+
+		sd, err := p.State()
+		if err != nil {
+			return nil, fmt.Errorf("unable to read provider state: %w", err)
+		}
+
+		if !skipValidation {
+			log.WithFields("provider", p.ID().Name).Trace("validating state")
+			if err := sd.Verify(); err != nil {
+				return nil, fmt.Errorf("invalid provider state: %w", err)
+			}
+		}
+		states = append(states, *sd)
+	}
+	if !skipValidation {
+		log.Debugf("state validated for all providers")
+	}
+	return states, nil
+}
+
+func latestTimestamp(states []provider.State) time.Time {
+	var latest time.Time
+	for _, s := range states {
+		if s.Timestamp.After(latest) {
+			latest = s.Timestamp
+		}
+	}
+	return latest
 }

--- a/cmd/grype-db/cli/commands/build_test.go
+++ b/cmd/grype-db/cli/commands/build_test.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/anchore/grype-db/pkg/provider"
+)
+
+func Test_latestTimestamp(t *testing.T) {
+	tests := []struct {
+		name   string
+		states []provider.State
+		want   time.Time
+	}{
+		{
+			name: "happy path",
+			states: []provider.State{
+				{
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Timestamp: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Timestamp: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			want: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := latestTimestamp(tt.states); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("latestTimestamp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Today the DB timestamp is the oldest provider data timestamp, not the timestamp of when the DB was built. This reverses the semantics such that the latest data timestamp is used. This is helpful in scenarios when the cadence of DBs delivered is relatively high and the policy for failing providers is permissive. That means you can build many DBs with the same timestamp, which is not useful.