### PR TITLE
Add listing replicas

### DIFF
--- a/manager/src/grype_db_manager/cli/config.py
+++ b/manager/src/grype_db_manager/cli/config.py
@@ -82,6 +82,14 @@ class Validate:
 
 
 @dataclass()
+class ListingReplica:
+    listing_file_name: str = "listing.json"
+    s3_path: str | None = None
+    s3_bucket: str | None = None
+    aws_region: str | None = None
+
+
+@dataclass()
 class Distribution:
     listing_file_name: str = "listing.json"
     s3_path: str | None = None
@@ -89,6 +97,7 @@ class Distribution:
     s3_endpoint_url: str | None = None
     download_url_prefix: str | None = None
     aws_region: str | None = None
+    listing_replicas: list[ListingReplica] = field(default_factory=list)
 
 
 @dataclass

--- a/manager/src/grype_db_manager/cli/listing.py
+++ b/manager/src/grype_db_manager/cli/listing.py
@@ -25,7 +25,12 @@ def create_listing(cfg: config.Application, ignore_missing_listing: bool) -> str
     download_url_prefix = cfg.distribution.download_url_prefix
 
     # get existing listing file...
-    the_listing = db.listing.fetch(bucket=s3_bucket, path=s3_path, create_if_missing=ignore_missing_listing)
+    the_listing = db.listing.fetch(
+        bucket=s3_bucket,
+        path=s3_path,
+        filename=cfg.distribution.listing_file_name,
+        create_if_missing=ignore_missing_listing,
+    )
 
     # look for existing DBs in S3
     existing_paths_by_basename = distribution.existing_dbs_in_s3(
@@ -131,18 +136,39 @@ def upload_listing(cfg: config.Application, listing_file: str, ttl_seconds: int)
 
     s3_bucket = cfg.distribution.s3_bucket
     s3_path = cfg.distribution.s3_path
+    filename = cfg.distribution.listing_file_name
 
     with open(listing_file) as f:
         the_listing = db.Listing.from_json(f.read())
 
+    # upload the primary listing file
     s3utils.upload(
         bucket=s3_bucket,
-        key=the_listing.url(s3_path),
+        key=the_listing.url(s3_path, filename),
         contents=the_listing.to_json(),
         CacheControl=f"public,max-age={ttl_seconds}",
     )
 
     click.echo(f"{listing_file} uploaded to s3://{s3_bucket}/{s3_path}")
+
+    # upload to replicas
+    for replica in cfg.distribution.listing_replicas:
+        replica_s3_bucket = replica.s3_bucket or s3_bucket
+        replica_s3_path = replica.s3_path or s3_path
+        replica_filename = replica.listing_file_name or filename
+
+        if not replica_s3_bucket or not replica_s3_path:
+            logging.warning(f"skipping replica upload for {replica} because s3_bucket and s3_path are required")
+            continue
+
+        s3utils.upload(
+            bucket=replica_s3_bucket,
+            key=the_listing.url(replica_s3_path, replica_filename),
+            contents=the_listing.to_json(),
+            CacheControl=f"public,max-age={ttl_seconds}",
+        )
+
+        click.echo(f"{listing_file} uploaded to s3://{replica_s3_bucket}/{replica_s3_path}")
 
 
 @group.command(name="update", help="recreate a listing based off of S3 state, validate it, and upload it")

--- a/manager/src/grype_db_manager/db/listing.py
+++ b/manager/src/grype_db_manager/db/listing.py
@@ -140,8 +140,8 @@ class Listing:
                 logging.info(f"    entry: {entry}")
 
     @staticmethod
-    def url(path: str) -> str:
-        url = os.path.normpath("/".join([path, LISTING_FILENAME]).lstrip("/"))
+    def url(path: str, filename: str) -> str:
+        url = os.path.normpath("/".join([path, filename]).lstrip("/"))
         return urlunparse(urlparse(url))  # normalize the url
 
     def basenames(self) -> set[str]:
@@ -171,7 +171,7 @@ def empty_listing() -> Listing:
     return Listing(available={})
 
 
-def fetch(bucket: str, path: str, create_if_missing: bool = False) -> Listing:
+def fetch(bucket: str, path: str, filename: str, create_if_missing: bool = False) -> Listing:
     if not path or not bucket:
         if create_if_missing:
             logging.warning("no path or bucket specified, creating empty listing")
@@ -180,7 +180,7 @@ def fetch(bucket: str, path: str, create_if_missing: bool = False) -> Listing:
         raise ValueError(msg)
 
     logging.info(f"fetching existing listing from s3://{bucket}/{path}")
-    listing_path = Listing.url(path)
+    listing_path = Listing.url(path, filename)
     try:
         listing_contents = s3utils.get_s3_object_contents(
             bucket=bucket,

--- a/manager/src/grype_db_manager/grypedb.py
+++ b/manager/src/grype_db_manager/grypedb.py
@@ -462,11 +462,9 @@ class GrypeDB:
 
         env = dict(  # noqa: PIE804
             **os.environ.copy(),
-            **{
-                "GRYPE_DB_VUNNEL_ROOT": provider_root_dir,
-                "GRYPE_DB_CONFIG": config,
-                "GRYPE_DB_LOG_LEVEL": level,
-            },
+            GRYPE_DB_VUNNEL_ROOT=provider_root_dir,
+            GRYPE_DB_CONFIG=config,
+            GRYPE_DB_LOG_LEVEL=level,
         )
 
         ret = subprocess.check_call(cmd, env=env, shell=True)  # noqa: S602

--- a/manager/tests/unit/cli/fixtures/config/full.yaml
+++ b/manager/tests/unit/cli/fixtures/config/full.yaml
@@ -21,7 +21,12 @@ distribution:
   aws-region: us-west-2
   s3-endpoint-url: http://localhost:4566
   download-url-prefix: http://localhost:4566/testbucket
-
+  listing_replicas:
+    - awsRegion: us-west-2
+      listingFileName: listing.json
+      s3Bucket: testbucket
+      s3Path: grype/databases
+      
 schemaMappingFile: "mapping.json"
 
 validate:

--- a/manager/tests/unit/cli/test_config.py
+++ b/manager/tests/unit/cli/test_config.py
@@ -50,6 +50,7 @@ distribution:
   awsRegion: null
   downloadUrlPrefix: null
   listingFileName: listing.json
+  listingReplicas: []
   s3Bucket: null
   s3EndpointUrl: null
   s3Path: null
@@ -97,6 +98,11 @@ distribution:
   awsRegion: us-west-2
   downloadUrlPrefix: http://localhost:4566/testbucket
   listingFileName: listing.json
+  listingReplicas:
+    - awsRegion: us-west-2
+      listingFileName: listing.json
+      s3Bucket: testbucket
+      s3Path: grype/databases
   s3Bucket: testbucket
   s3EndpointUrl: http://localhost:4566
   s3Path: grype/databases

--- a/manager/tests/unit/db/test_listing.py
+++ b/manager/tests/unit/db/test_listing.py
@@ -85,7 +85,7 @@ def test_listing_add_sorts_by_date():
     ),
 )
 def test_listing_url(s3_path, expected):
-    assert expected == db.Listing.url(s3_path)
+    assert expected == db.Listing.url(s3_path, "listing.json")
 
 
 def test_listing_basenames():


### PR DESCRIPTION
This change allows for grype-db listing files to be replicated to multiple S3 locations via grype-db-manager application configuration:
```yaml
listing-file-name: listing.json
s3-path: grype/databases
s3-bucket: my-awesome-bucket.io
aws-region: us-west-2
download-url-prefix: https://my-awesome-bucket.io

# this maps to feed service API version paths
listing_replicas:
  - s3-path: v1/grype/databases
  - s3-path: v2/grype/databases
    s3-bucket: another-bucket.io

```