### PR TITLE
Fail cache status on empty results

### DIFF
--- a/cmd/grype-db/cli/commands/cache_status.go
+++ b/cmd/grype-db/cli/commands/cache_status.go
@@ -159,7 +159,7 @@ func validateCount(cfg cacheStatusConfig, counter func() (int64, error)) (int64,
 
 // validateRequestedProviders takes the set of providers found on disk, and the set of providers
 // requested at the command line. It returns the subset of providers on disk that were requested.
-// If providers were requested that are not present on disk, it returns an error.\
+// If providers were requested that are not present on disk, it returns an error.
 // If no providers are explicitly requested, it returns the entire set.
 func validateRequestedProviders(providersOnDisk []string, requestedProviders []string) ([]string, error) {
 	if len(requestedProviders) == 0 {

--- a/cmd/grype-db/cli/commands/cache_status_test.go
+++ b/cmd/grype-db/cli/commands/cache_status_test.go
@@ -2,8 +2,9 @@ package commands
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_validateCount(t *testing.T) {

--- a/cmd/grype-db/cli/commands/cache_status_test.go
+++ b/cmd/grype-db/cli/commands/cache_status_test.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_validateCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     cacheStatusConfig
+		counter func() (int64, error)
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "empty count passes when min-rows is -1",
+			cfg:  cacheStatusConfig{minRows: -1},
+			counter: func() (int64, error) {
+				return 0, nil
+			},
+		},
+		{
+			name: "empty count fails when min-rows is 0",
+			cfg:  cacheStatusConfig{minRows: 0},
+			counter: func() (int64, error) {
+				return 0, nil
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "large count passes when min-rows is less",
+			cfg:  cacheStatusConfig{minRows: 12},
+			counter: func() (int64, error) {
+				return 13, nil
+			},
+		},
+		{
+			name: "error is reported when counter returns error",
+			counter: func() (int64, error) {
+				return 0, fmt.Errorf("could not count records")
+			},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = assert.NoError
+			}
+			tt.wantErr(t, validateCount(tt.cfg, tt.counter))
+		})
+	}
+}

--- a/cmd/grype-db/cli/commands/cache_status_test.go
+++ b/cmd/grype-db/cli/commands/cache_status_test.go
@@ -12,6 +12,7 @@ func Test_validateCount(t *testing.T) {
 		name    string
 		cfg     cacheStatusConfig
 		counter func() (int64, error)
+		want    int64
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
@@ -35,6 +36,7 @@ func Test_validateCount(t *testing.T) {
 			counter: func() (int64, error) {
 				return 13, nil
 			},
+			want: 13,
 		},
 		{
 			name: "error is reported when counter returns error",
@@ -49,7 +51,51 @@ func Test_validateCount(t *testing.T) {
 			if tt.wantErr == nil {
 				tt.wantErr = assert.NoError
 			}
-			tt.wantErr(t, validateCount(tt.cfg, tt.counter))
+			count, err := validateCount(tt.cfg, tt.counter)
+			if !tt.wantErr(t, err) {
+				return
+			}
+			assert.Equal(t, tt.want, count)
+		})
+	}
+}
+
+func Test_validateRequestedProviders(t *testing.T) {
+	tests := []struct {
+		name               string
+		providersOnDisk    []string
+		requestedProviders []string
+		want               []string
+		wantErr            assert.ErrorAssertionFunc
+	}{
+		{
+			name:            "no requested providers means on disk state is ok",
+			providersOnDisk: []string{"alpine", "some-provider", "void-linux", "gentoo"},
+			want:            []string{"alpine", "some-provider", "void-linux", "gentoo"},
+		},
+		{
+			name:               "requesting subset of providers works",
+			providersOnDisk:    []string{"alpine", "some-provider", "void-linux", "gentoo"},
+			requestedProviders: []string{"alpine", "void-linux"},
+			want:               []string{"alpine", "void-linux"},
+		},
+		{
+			name:               "requesting missing provider result in error",
+			providersOnDisk:    []string{"alpine", "some-provider", "void-linux", "gentoo"},
+			requestedProviders: []string{"alpine", "void-linux", "missing"},
+			wantErr:            assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateRequestedProviders(tt.providersOnDisk, tt.requestedProviders)
+			if tt.wantErr == nil {
+				tt.wantErr = assert.NoError
+			}
+			if !tt.wantErr(t, err, fmt.Sprintf("validateRequestedProviders(%v, %v)", tt.providersOnDisk, tt.requestedProviders)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "validateRequestedProviders(%v, %v)", tt.providersOnDisk, tt.requestedProviders)
 		})
 	}
 }


### PR DESCRIPTION
This adds a flag to grype-db cache status to require that a certain number of rows be present in the database. By default, the value is zero, so that empty databases fail cache status. If empty databases are acceptable, `--min-rows -1` can be passed.

Previously, `grype-db cache status -p $SOME-PROVIDER` would exit zero in two situations where it probably shouldn't have:
1. Provider `$SOME-PROVIDER` is not present in the workspace _at all_. Hard to say a totally absent provider is valid.
2. The Provider `$SOME-PROVIDER` is present, but the results.db in their workspace has zero rows.

The intent of this PR is to guard against accidentally pushing workspace cache when the provider didn't find anything or restoring the provider cache failed.