### PR TITLE
fix: ensure normalization of all severity values

### DIFF
--- a/pkg/process/v1/writer.go
+++ b/pkg/process/v1/writer.go
@@ -103,6 +103,7 @@ func (w writer) Close() error {
 }
 
 func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.VulnerabilityMetadataStoreReader) {
+	metadata.Severity = string(data.ParseSeverity(metadata.Severity))
 	if metadata.Severity != "" && strings.ToLower(metadata.Severity) != "unknown" {
 		return
 	}
@@ -123,8 +124,8 @@ func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.V
 	}
 
 	newSeverity := string(data.ParseSeverity(m.Severity))
-
-	log.WithFields("id", metadata.ID, "record-source", metadata.RecordSource, "from", metadata.Severity, "to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
-
+	if newSeverity != metadata.Severity {
+		log.WithFields("id", metadata.ID, "record-source", metadata.RecordSource, "from", metadata.Severity, "to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
+	}
 	metadata.Severity = newSeverity
 }

--- a/pkg/process/v1/writer_test.go
+++ b/pkg/process/v1/writer_test.go
@@ -51,29 +51,37 @@ func Test_normalizeSeverity(t *testing.T) {
 		expected        data.Severity
 	}{
 		{
-			name:            "skip missing metadata",
+			name:            "missing severity set to Unknown",
 			initialSeverity: "",
 			recordSource:    "test",
 			reader:          &mockReader{},
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "skip non-cve records metadata",
+			name:            "non-cve records metadata missing severity set to Unknown",
 			cveID:           "GHSA-1234-1234-1234",
 			initialSeverity: "",
 			recordSource:    "test",
 			reader:          newDeadMockReader(), // should not be used
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "override empty severity",
+			name:            "non-cve records metadata with severity set should not be overriden",
+			cveID:           "GHSA-1234-1234-1234",
+			initialSeverity: "high",
+			recordSource:    "test",
+			reader:          newMockReader("critical"), // should not be used
+			expected:        data.SeverityHigh,
+		},
+		{
+			name:            "override empty severity from NVD",
 			initialSeverity: "",
 			recordSource:    "test",
 			reader:          newMockReader("low"),
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "override unknown severity",
+			name:            "override unknown severity from NVD",
 			initialSeverity: "unknown",
 			recordSource:    "test",
 			reader:          newMockReader("low"),
@@ -94,11 +102,11 @@ func Test_normalizeSeverity(t *testing.T) {
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "db errors should not fail or modify the record",
+			name:            "db errors should not fail or modify the record other than normalizing unset value",
 			initialSeverity: "",
 			recordSource:    "test",
 			reader:          newDeadMockReader(),
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/process/v2/writer.go
+++ b/pkg/process/v2/writer.go
@@ -103,6 +103,7 @@ func (w writer) Close() error {
 }
 
 func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.VulnerabilityMetadataStoreReader) {
+	metadata.Severity = string(data.ParseSeverity(metadata.Severity))
 	if metadata.Severity != "" && strings.ToLower(metadata.Severity) != "unknown" {
 		return
 	}
@@ -123,8 +124,8 @@ func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.V
 	}
 
 	newSeverity := string(data.ParseSeverity(m.Severity))
-
-	log.WithFields("id", metadata.ID, "record-source", metadata.RecordSource, "from", metadata.Severity, "to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
-
+	if newSeverity != metadata.Severity {
+		log.WithFields("id", metadata.ID, "record-source", metadata.RecordSource, "from", metadata.Severity, "to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
+	}
 	metadata.Severity = newSeverity
 }

--- a/pkg/process/v2/writer_test.go
+++ b/pkg/process/v2/writer_test.go
@@ -51,29 +51,37 @@ func Test_normalizeSeverity(t *testing.T) {
 		expected        data.Severity
 	}{
 		{
-			name:            "skip missing metadata",
+			name:            "missing severity set to Unknown",
 			initialSeverity: "",
 			recordSource:    "test",
 			reader:          &mockReader{},
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "skip non-cve records metadata",
+			name:            "non-cve records metadata missing severity set to Unknown",
 			cveID:           "GHSA-1234-1234-1234",
 			initialSeverity: "",
 			recordSource:    "test",
 			reader:          newDeadMockReader(), // should not be used
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "override empty severity",
+			name:            "non-cve records metadata with severity set should not be overriden",
+			cveID:           "GHSA-1234-1234-1234",
+			initialSeverity: "high",
+			recordSource:    "test",
+			reader:          newMockReader("critical"), // should not be used
+			expected:        data.SeverityHigh,
+		},
+		{
+			name:            "override empty severity from NVD",
 			initialSeverity: "",
 			recordSource:    "test",
 			reader:          newMockReader("low"),
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "override unknown severity",
+			name:            "override unknown severity from NVD",
 			initialSeverity: "unknown",
 			recordSource:    "test",
 			reader:          newMockReader("low"),
@@ -94,11 +102,11 @@ func Test_normalizeSeverity(t *testing.T) {
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "db errors should not fail or modify the record",
+			name:            "db errors should not fail or modify the record other than normalizing unset value",
 			initialSeverity: "",
 			recordSource:    "test",
 			reader:          newDeadMockReader(),
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/process/v3/writer.go
+++ b/pkg/process/v3/writer.go
@@ -104,6 +104,7 @@ func (w writer) Close() error {
 }
 
 func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.VulnerabilityMetadataStoreReader) {
+	metadata.Severity = string(data.ParseSeverity(metadata.Severity))
 	if metadata.Severity != "" && strings.ToLower(metadata.Severity) != "unknown" {
 		return
 	}
@@ -124,8 +125,8 @@ func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.V
 	}
 
 	newSeverity := string(data.ParseSeverity(m.Severity))
-
-	log.WithFields("id", metadata.ID, "namespace", metadata.Namespace, "from", metadata.Severity, "to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
-
+	if newSeverity != metadata.Severity {
+		log.WithFields("id", metadata.ID, "namespace", metadata.Namespace, "sev-from", metadata.Severity, "sev-to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
+	}
 	metadata.Severity = newSeverity
 }

--- a/pkg/process/v3/writer_test.go
+++ b/pkg/process/v3/writer_test.go
@@ -51,28 +51,37 @@ func Test_normalizeSeverity(t *testing.T) {
 		expected        data.Severity
 	}{
 		{
-			name:            "skip missing metadata",
+			name:            "missing severity set to Unknown",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          &mockReader{},
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "skip non-cve records metadata",
+			name:            "non-cve records metadata missing severity set to Unknown",
 			cveID:           "GHSA-1234-1234-1234",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newDeadMockReader(), // should not be used
-			expected:        "",
-		}, {
-			name:            "override empty severity",
+			expected:        data.SeverityUnknown,
+		},
+		{
+			name:            "non-cve records metadata with severity set should not be overriden",
+			cveID:           "GHSA-1234-1234-1234",
+			initialSeverity: "high",
+			namespace:       "test",
+			reader:          newMockReader("critical"), // should not be used
+			expected:        data.SeverityHigh,
+		},
+		{
+			name:            "override empty severity from NVD",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newMockReader("low"),
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "override unknown severity",
+			name:            "override unknown severity from NVD",
 			initialSeverity: "unknown",
 			namespace:       "test",
 			reader:          newMockReader("low"),
@@ -88,16 +97,16 @@ func Test_normalizeSeverity(t *testing.T) {
 		{
 			name:            "ignore nvd records",
 			initialSeverity: "Low",
-			namespace:       "nvd",
+			namespace:       "nvdv2:cves",
 			reader:          newDeadMockReader(), // should not be used
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "db errors should not fail or modify the record",
+			name:            "db errors should not fail or modify the record other than normalizing unset value",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newDeadMockReader(),
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/process/v4/writer.go
+++ b/pkg/process/v4/writer.go
@@ -111,6 +111,7 @@ func (w writer) Close() error {
 }
 
 func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.VulnerabilityMetadataStoreReader) {
+	metadata.Severity = string(data.ParseSeverity(metadata.Severity))
 	if metadata.Severity != "" && strings.ToLower(metadata.Severity) != "unknown" {
 		return
 	}
@@ -131,8 +132,8 @@ func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.V
 	}
 
 	newSeverity := string(data.ParseSeverity(m.Severity))
-
-	log.WithFields("id", metadata.ID, "namespace", metadata.Namespace, "from", metadata.Severity, "to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
-
+	if newSeverity != metadata.Severity {
+		log.WithFields("id", metadata.ID, "namespace", metadata.Namespace, "sev-from", metadata.Severity, "sev-to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
+	}
 	metadata.Severity = newSeverity
 }

--- a/pkg/process/v4/writer_test.go
+++ b/pkg/process/v4/writer_test.go
@@ -51,29 +51,37 @@ func Test_normalizeSeverity(t *testing.T) {
 		expected        data.Severity
 	}{
 		{
-			name:            "skip missing metadata",
+			name:            "missing severity set to Unknown",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          &mockReader{},
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "skip non-cve records metadata",
+			name:            "non-cve records metadata missing severity set to Unknown",
 			cveID:           "GHSA-1234-1234-1234",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newDeadMockReader(), // should not be used
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "override empty severity",
+			name:            "non-cve records metadata with severity set should not be overriden",
+			cveID:           "GHSA-1234-1234-1234",
+			initialSeverity: "high",
+			namespace:       "test",
+			reader:          newMockReader("critical"), // should not be used
+			expected:        data.SeverityHigh,
+		},
+		{
+			name:            "override empty severity from NVD",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newMockReader("low"),
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "override unknown severity",
+			name:            "override unknown severity from NVD",
 			initialSeverity: "unknown",
 			namespace:       "test",
 			reader:          newMockReader("low"),
@@ -89,16 +97,16 @@ func Test_normalizeSeverity(t *testing.T) {
 		{
 			name:            "ignore nvd records",
 			initialSeverity: "Low",
-			namespace:       "nvd:cpe",
+			namespace:       "nvdv2:cves",
 			reader:          newDeadMockReader(), // should not be used
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "db errors should not fail or modify the record",
+			name:            "db errors should not fail or modify the record other than normalizing unset value",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newDeadMockReader(),
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/process/v5/writer.go
+++ b/pkg/process/v5/writer.go
@@ -112,6 +112,7 @@ func (w writer) Close() error {
 }
 
 func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.VulnerabilityMetadataStoreReader) {
+	metadata.Severity = string(data.ParseSeverity(metadata.Severity))
 	if metadata.Severity != "" && strings.ToLower(metadata.Severity) != "unknown" {
 		return
 	}
@@ -132,8 +133,8 @@ func normalizeSeverity(metadata *grypeDB.VulnerabilityMetadata, reader grypeDB.V
 	}
 
 	newSeverity := string(data.ParseSeverity(m.Severity))
-
-	log.WithFields("id", metadata.ID, "namespace", metadata.Namespace, "sev-from", metadata.Severity, "sev-to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
-
+	if newSeverity != metadata.Severity {
+		log.WithFields("id", metadata.ID, "namespace", metadata.Namespace, "sev-from", metadata.Severity, "sev-to", newSeverity).Trace("overriding irrelevant severity with data from NVD record")
+	}
 	metadata.Severity = newSeverity
 }

--- a/pkg/process/v5/writer_test.go
+++ b/pkg/process/v5/writer_test.go
@@ -51,29 +51,37 @@ func Test_normalizeSeverity(t *testing.T) {
 		expected        data.Severity
 	}{
 		{
-			name:            "skip missing metadata",
+			name:            "missing severity set to Unknown",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          &mockReader{},
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "skip non-cve records metadata",
+			name:            "non-cve records metadata missing severity set to Unknown",
 			cveID:           "GHSA-1234-1234-1234",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newDeadMockReader(), // should not be used
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 		{
-			name:            "override empty severity",
+			name:            "non-cve records metadata with severity set should not be overriden",
+			cveID:           "GHSA-1234-1234-1234",
+			initialSeverity: "high",
+			namespace:       "test",
+			reader:          newMockReader("critical"), // should not be used
+			expected:        data.SeverityHigh,
+		},
+		{
+			name:            "override empty severity from NVD",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newMockReader("low"),
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "override unknown severity",
+			name:            "override unknown severity from NVD",
 			initialSeverity: "unknown",
 			namespace:       "test",
 			reader:          newMockReader("low"),
@@ -89,16 +97,16 @@ func Test_normalizeSeverity(t *testing.T) {
 		{
 			name:            "ignore nvd records",
 			initialSeverity: "Low",
-			namespace:       "nvd:cpe",
+			namespace:       "nvdv2:cves",
 			reader:          newDeadMockReader(), // should not be used
 			expected:        data.SeverityLow,
 		},
 		{
-			name:            "db errors should not fail or modify the record",
+			name:            "db errors should not fail or modify the record other than normalizing unset value",
 			initialSeverity: "",
 			namespace:       "test",
 			reader:          newDeadMockReader(),
-			expected:        "",
+			expected:        data.SeverityUnknown,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Ensure that all severity values get normalized.  Previously normalization would be skipped for any records that weren't unknown, were from the NVD namespace, or were not based on CVE ids.  In those cases what should be skipped is defaulting to the NVD provider values when unknown, but not normalizing to a set enumeration of values