### PR TITLE
Remove trailing / in listing create

### DIFF
--- a/manager/src/grype_db_manager/cli/listing.py
+++ b/manager/src/grype_db_manager/cli/listing.py
@@ -22,7 +22,7 @@ def group(_: config.Application) -> None:
 def create_listing(cfg: config.Application, ignore_missing_listing: bool) -> str:
     s3_bucket = cfg.distribution.s3_bucket
     s3_path = cfg.distribution.s3_path
-    download_url_prefix = cfg.distribution.download_url_prefix.removesuffix("/")
+    download_url_prefix = cfg.distribution.download_url_prefix
 
     # get existing listing file...
     the_listing = db.listing.fetch(

--- a/manager/src/grype_db_manager/cli/listing.py
+++ b/manager/src/grype_db_manager/cli/listing.py
@@ -22,7 +22,7 @@ def group(_: config.Application) -> None:
 def create_listing(cfg: config.Application, ignore_missing_listing: bool) -> str:
     s3_bucket = cfg.distribution.s3_bucket
     s3_path = cfg.distribution.s3_path
-    download_url_prefix = cfg.distribution.download_url_prefix
+    download_url_prefix = cfg.distribution.download_url_prefix.removesuffix("/")
 
     # get existing listing file...
     the_listing = db.listing.fetch(

--- a/manager/src/grype_db_manager/distribution.py
+++ b/manager/src/grype_db_manager/distribution.py
@@ -6,7 +6,7 @@ import logging
 import os
 import tempfile
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse, urlunparse, urljoin
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import iso8601
 

--- a/manager/src/grype_db_manager/distribution.py
+++ b/manager/src/grype_db_manager/distribution.py
@@ -67,7 +67,7 @@ def listing_entries_dbs_in_s3(
             meta = metadata.from_archive(path=local_path)
 
             # create a new listing entry and add it to the listing
-            url = os.path.join(download_url_prefix, s3_path, basename)
+            url = f"{download_url_prefix.strip('/')}/{s3_path.strip('/')}/{basename.strip('/')}"
             url = urlunparse(urlparse(url))  # normalize the url
 
             yield listing.Entry(

--- a/manager/src/grype_db_manager/distribution.py
+++ b/manager/src/grype_db_manager/distribution.py
@@ -6,7 +6,7 @@ import logging
 import os
 import tempfile
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, urljoin
 
 import iso8601
 
@@ -67,7 +67,8 @@ def listing_entries_dbs_in_s3(
             meta = metadata.from_archive(path=local_path)
 
             # create a new listing entry and add it to the listing
-            url = f"{download_url_prefix}/{s3_path}/{basename}"
+            path_part = os.path.join(s3_path, basename)
+            url = urljoin(download_url_prefix, path_part)
             url = urlunparse(urlparse(url))  # normalize the url
 
             yield listing.Entry(

--- a/manager/src/grype_db_manager/distribution.py
+++ b/manager/src/grype_db_manager/distribution.py
@@ -6,7 +6,7 @@ import logging
 import os
 import tempfile
 from typing import TYPE_CHECKING
-from urllib.parse import urljoin, urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse
 
 import iso8601
 
@@ -67,8 +67,7 @@ def listing_entries_dbs_in_s3(
             meta = metadata.from_archive(path=local_path)
 
             # create a new listing entry and add it to the listing
-            path_part = os.path.join(s3_path, basename)
-            url = urljoin(download_url_prefix, path_part)
+            url = os.path.join(download_url_prefix, s3_path, basename)
             url = urlunparse(urlparse(url))  # normalize the url
 
             yield listing.Entry(

--- a/manager/tests/cli/run.sh
+++ b/manager/tests/cli/run.sh
@@ -20,7 +20,7 @@ for script in $files; do
 done
 echo
 
-# run all scripts in the current directory named case-*.sh and exit on first failure
+# run all scripts in the current directory named workflow-*.sh and exit on first failure
 status=0
 for script in $files; do
     bash -c "./$script" || { status=1; break; }

--- a/manager/tests/unit/cli/fixtures/listing/create-new-db/.grype-db-manager.yaml
+++ b/manager/tests/unit/cli/fixtures/listing/create-new-db/.grype-db-manager.yaml
@@ -6,4 +6,4 @@ distribution:
   s3-path: grype/databases
   s3-bucket: testbucket
   aws-region: us-west-2
-  download-url-prefix: http://localhost:4566/testbucket
+  download-url-prefix: http://localhost:4566/testbucket/ # assert that trailing / is trimmed


### PR DESCRIPTION
Otherwise, the download-url-prefix http://example.com/ will result in listing files which are unparseable because they have // in the path which results in an incorrect S3 key.