### PR TITLE
chore: exclude manager from go tooling

### DIFF
--- a/manager/go.mod
+++ b/manager/go.mod
@@ -1,0 +1,1 @@
+module manager


### PR DESCRIPTION
Running `go get github.com/anchore/grype-db` fails because of files containing `:` characters in the `manager` python directory tree. Adding the `go.mod` will cause this tree to be excluded from the top-level module.