### PR TITLE
feat: add --results-only switch to grype-db cache backup

### DIFF
--- a/cmd/grype-db/cli/commands/cache_backup.go
+++ b/cmd/grype-db/cli/commands/cache_backup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -150,7 +151,7 @@ func archiveProvider(cfg cacheBackupConfig, root string, name string, writer *ta
 	)
 }
 
-func pathWalker(path string, info os.FileInfo, err error, cfg cacheBackupConfig, name string, writer *tar.Writer) error {
+func pathWalker(p string, info os.FileInfo, err error, cfg cacheBackupConfig, name string, writer *tar.Writer) error {
 	if err != nil {
 		return err
 	}
@@ -159,12 +160,12 @@ func pathWalker(path string, info os.FileInfo, err error, cfg cacheBackupConfig,
 		return nil
 	}
 	if cfg.Results.ResultsOnly {
-		if strings.Compare(path, name+"/metadata.json") == 0 {
-			log.WithFields("file", name+"/metadata.json").Debug("Marking metadata stale")
+		if strings.Compare(p, path.Join(name, "metadata.json")) == 0 {
+			log.WithFields("file", path.Join(name, "metadata.json")).Debug("Marking metadata stale")
 
 			// Mark metadata stale
 			var state provider.State
-			f, err := os.Open(path)
+			f, err := os.Open(p)
 			if err != nil {
 				return err
 			}
@@ -182,15 +183,15 @@ func pathWalker(path string, info os.FileInfo, err error, cfg cacheBackupConfig,
 				return err
 			}
 
-			return addBytesToArchive(writer, path, stateJSON, info)
+			return addBytesToArchive(writer, p, stateJSON, info)
 		}
-		if strings.HasPrefix(path, name+"/input") {
-			log.WithFields("path", path).Debug("Skipping input directory")
+		if strings.HasPrefix(p, path.Join(name, "input")) {
+			log.WithFields("path", p).Debug("Skipping input directory")
 			return nil
 		}
 	}
 
-	return addToArchive(writer, path)
+	return addToArchive(writer, p)
 }
 
 func addToArchive(writer *tar.Writer, filename string) error {

--- a/cmd/grype-db/cli/commands/cache_backup.go
+++ b/cmd/grype-db/cli/commands/cache_backup.go
@@ -3,10 +3,12 @@ package commands
 import (
 	"archive/tar"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/scylladb/go-set/strset"
 	"github.com/spf13/cobra"
@@ -27,14 +29,18 @@ type cacheBackupConfig struct {
 		options.Store     `yaml:",inline" mapstructure:",squash"`
 		options.Selection `yaml:",inline" mapstructure:",squash"`
 	} `yaml:"provider" json:"provider" mapstructure:"provider"`
+	options.Results `yaml:"results" json:"results" mapstructure:"results"`
 }
 
 func (o *cacheBackupConfig) AddFlags(flags *pflag.FlagSet) {
-	options.AddAllFlags(flags, &o.CacheArchive, &o.Provider.Store, &o.Provider.Selection)
+	options.AddAllFlags(flags, &o.CacheArchive, &o.Provider.Store, &o.Provider.Selection, &o.Results)
 }
 
 func (o *cacheBackupConfig) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
-	return options.BindAllFlags(flags, v, &o.CacheArchive, &o.Provider.Store, &o.Provider.Selection)
+	if err := options.Bind(v, "results.results-only", flags.Lookup("results-only")); err != nil {
+		return err
+	}
+	return options.BindAllFlags(flags, v, &o.CacheArchive, &o.Provider.Store, &o.Provider.Selection, &o.Results)
 }
 
 func CacheBackup(app *application.Application) *cobra.Command {
@@ -43,6 +49,7 @@ func CacheBackup(app *application.Application) *cobra.Command {
 	}
 	cfg.Provider.Store = options.DefaultStore()
 	cfg.Provider.Selection = options.DefaultSelection()
+	cfg.Results = options.DefaultResults()
 
 	cmd := &cobra.Command{
 		Use:     "backup",
@@ -111,7 +118,7 @@ func cacheBackup(cfg cacheBackupConfig) error {
 		}
 
 		log.WithFields("provider", name).Debug("archiving data")
-		if err := archiveProvider(cfg.Provider.Root, name, tw); err != nil {
+		if err := archiveProvider(cfg, cfg.Provider.Root, name, tw); err != nil {
 			return err
 		}
 	}
@@ -121,7 +128,7 @@ func cacheBackup(cfg cacheBackupConfig) error {
 	return nil
 }
 
-func archiveProvider(root string, name string, writer *tar.Writer) error {
+func archiveProvider(cfg cacheBackupConfig, root string, name string, writer *tar.Writer) error {
 	wd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -138,12 +145,31 @@ func archiveProvider(root string, name string, writer *tar.Writer) error {
 
 	return filepath.Walk(name,
 		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
 			if info.IsDir() {
 				return nil
+			}
+			if cfg.Results.ResultsOnly {
+				if strings.Compare(path, name+"/metadata.json") == 0 {
+					log.WithFields("file", name+"/metadata.json").Debug("Marking metadata stale")
+					// Mark metadata stale
+					state, err := provider.ReadState(path)
+					if err != nil {
+						return err
+					}
+
+					state.Stale = true
+					// Stream this to the archive
+					stateJSON, err := json.MarshalIndent(state, "", "  ")
+					if err != nil {
+						return err
+					}
+
+					return addBytesToArchive(writer, path, stateJSON, info)
+				}
+				if strings.HasPrefix(path, name+"/input") {
+					log.WithFields("path", path).Debug("Skipping input directory")
+					return nil
+				}
 			}
 
 			return addToArchive(writer, path)
@@ -182,6 +208,32 @@ func addToArchive(writer *tar.Writer, filename string) error {
 	}
 
 	_, err = io.Copy(writer, file)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addBytesToArchive(writer *tar.Writer, filename string, bytes []byte, info os.FileInfo) error {
+	log.WithFields("path", filename).Trace("adding stream to archive")
+
+	header, err := tar.FileInfoHeader(info, info.Name())
+	if err != nil {
+		return err
+	}
+	header.Name = filename
+	header.Size = int64(len(bytes))
+	err = writer.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(bytes)
+	if err != nil {
+		return err
+	}
+	err = writer.Flush()
 	if err != nil {
 		return err
 	}

--- a/cmd/grype-db/cli/commands/cache_backup.go
+++ b/cmd/grype-db/cli/commands/cache_backup.go
@@ -151,8 +151,16 @@ func archiveProvider(cfg cacheBackupConfig, root string, name string, writer *ta
 			if cfg.Results.ResultsOnly {
 				if strings.Compare(path, name+"/metadata.json") == 0 {
 					log.WithFields("file", name+"/metadata.json").Debug("Marking metadata stale")
+
 					// Mark metadata stale
-					state, err := provider.ReadState(path)
+					var state provider.State
+					f, err := os.Open(path)
+					if err != nil {
+						return err
+					}
+					defer f.Close()
+
+					err = json.NewDecoder(f).Decode(&state)
 					if err != nil {
 						return err
 					}

--- a/cmd/grype-db/cli/commands/cache_backup_test.go
+++ b/cmd/grype-db/cli/commands/cache_backup_test.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"path"
+	"testing"
+
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype-db/cmd/grype-db/cli/options"
+	"github.com/anchore/grype-db/pkg/provider"
+)
+
+func Test_archiveProvider(t *testing.T) {
+	type args struct {
+		cfg  cacheBackupConfig
+		root string
+		name string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantNames      *strset.Set
+		wantStateStale bool
+		wantErr        assert.ErrorAssertionFunc
+	}{
+		{
+			name: "default config includes input",
+			args: args{
+				cfg: cacheBackupConfig{
+					Results: options.Results{
+						ResultsOnly: false,
+					},
+				},
+				root: "test-fixtures/test-root",
+				name: "test-provider",
+			},
+			wantStateStale: false,
+			wantNames: strset.New([]string{
+				"test-provider/input/some-input-file.txt",
+				"test-provider/metadata.json",
+				"test-provider/results/results.db",
+			}...),
+			wantErr: nil,
+		},
+		{
+			name: "results only excludes input",
+			args: args{
+				cfg: cacheBackupConfig{
+					Results: options.Results{
+						ResultsOnly: true,
+					},
+				},
+				root: "test-fixtures/test-root",
+				name: "test-provider",
+			},
+			wantNames: strset.New(
+				"test-provider/metadata.json",
+				"test-provider/results/results.db",
+			),
+			wantStateStale: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+			tw := tar.NewWriter(&b)
+			err := archiveProvider(tt.args.cfg, tt.args.root, tt.args.name, tw)
+			if tt.wantErr != nil {
+				tt.wantErr(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			r := bytes.NewReader(b.Bytes())
+			var state provider.State
+			foundNames := strset.New()
+			tr := tar.NewReader(r)
+			for {
+				next, nextErr := tr.Next()
+				if errors.Is(nextErr, io.EOF) {
+					break
+				}
+				require.NoError(t, nextErr)
+				if next.Name == path.Join(tt.args.name, "metadata.json") {
+					err = json.NewDecoder(tr).Decode(&state)
+					require.NoError(t, err)
+				}
+				foundNames.Add(next.Name)
+			}
+			assert.Equalf(t, tt.wantStateStale, state.Stale, "state had wrong staleness")
+			setDiff := strset.SymmetricDifference(tt.wantNames, foundNames)
+			assert.True(t, setDiff.IsEmpty())
+		})
+	}
+}

--- a/cmd/grype-db/cli/commands/test-fixtures/test-root/test-provider/input/some-input-file.txt
+++ b/cmd/grype-db/cli/commands/test-fixtures/test-root/test-provider/input/some-input-file.txt
@@ -1,0 +1,1 @@
+input-file

--- a/cmd/grype-db/cli/commands/test-fixtures/test-root/test-provider/metadata.json
+++ b/cmd/grype-db/cli/commands/test-fixtures/test-root/test-provider/metadata.json
@@ -1,0 +1,18 @@
+{
+  "provider": "wolfi",
+  "urls": [
+    "https://packages.wolfi.dev/os/security.json"
+  ],
+  "store": "sqlite",
+  "timestamp": "2024-03-25T01:26:38.371438+00:00",
+  "version": 1,
+  "listing": {
+    "digest": "00dfa461d5d03954",
+    "path": "checksums",
+    "algorithm": "xxh64"
+  },
+  "schema": {
+    "version": "1.0.1",
+    "url": "https://raw.githubusercontent.com/anchore/vunnel/main/schema/provider-workspace-state/schema-1.0.1.json"
+  }
+}

--- a/cmd/grype-db/cli/commands/test-fixtures/test-root/test-provider/results/results.db
+++ b/cmd/grype-db/cli/commands/test-fixtures/test-root/test-provider/results/results.db
@@ -1,0 +1,1 @@
+results-file

--- a/cmd/grype-db/cli/options/results.go
+++ b/cmd/grype-db/cli/options/results.go
@@ -1,0 +1,28 @@
+package options
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+var _ Interface = &Results{}
+
+type Results struct {
+	ResultsOnly bool `yaml:"results-only" json:"results-only" mapstructure:"results-only"`
+}
+
+func (r Results) AddFlags(flags *pflag.FlagSet) {
+	flags.BoolVarP(
+		&r.ResultsOnly,
+		"results-only", "r", r.ResultsOnly,
+		"only backup the results and ignore the input directories (default: false)",
+	)
+}
+
+func (r Results) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
+	return Bind(v, "results.results-only", flags.Lookup("results-only"))
+}
+
+func DefaultResults() Results {
+	return Results{ResultsOnly: false}
+}

--- a/pkg/provider/state.go
+++ b/pkg/provider/state.go
@@ -26,6 +26,7 @@ type State struct {
 	Timestamp        time.Time `json:"timestamp"`
 	Listing          *File     `json:"listing"`
 	Store            string    `json:"store"`
+	Stale            bool      `json:"stale"`
 	resultFileStates []File
 }
 
@@ -89,6 +90,18 @@ func ReadState(location string) (*State, error) {
 	log.WithFields("duration", time.Since(start), "entries", len(sd.resultFileStates)).Trace("loaded result listing file")
 
 	return &sd, nil
+}
+
+func WriteState(location string, sd *State) error {
+	by, err := json.MarshalIndent(sd, "", "  ")
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(location, by, 0644) // nolint:gosec
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (sd State) ResultPath(filename string) string {

--- a/pkg/provider/state.go
+++ b/pkg/provider/state.go
@@ -92,18 +92,6 @@ func ReadState(location string) (*State, error) {
 	return &sd, nil
 }
 
-func WriteState(location string, sd *State) error {
-	by, err := json.MarshalIndent(sd, "", "  ")
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(location, by, 0644) // nolint:gosec
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (sd State) ResultPath(filename string) string {
 	return filepath.Join(sd.root, filename)
 }


### PR DESCRIPTION
adding a --results-only switch to grype-db cache backup that ignores input directories