### PR TITLE
chore: add workflow to download latest db and listing periodically

### DIFF
--- a/.github/scripts/curl-timing-info-template.txt
+++ b/.github/scripts/curl-timing-info-template.txt
@@ -1,0 +1,8 @@
+     time_namelookup:  %{time_namelookup}s\n
+        time_connect:  %{time_connect}s\n
+     time_appconnect:  %{time_appconnect}s\n
+    time_pretransfer:  %{time_pretransfer}s\n
+       time_redirect:  %{time_redirect}s\n
+  time_starttransfer:  %{time_starttransfer}s\n
+                     ----------\n
+          time_total:  %{time_total}s\n

--- a/.github/scripts/download-listing-and-db.sh
+++ b/.github/scripts/download-listing-and-db.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -x
+
+timing_file="$(dirname $0)/curl-timing-info-template.txt"
+
+test_download() {
+  url=$1
+
+  # download with IPv6
+  curl -vsL6 -w "@$timing_file" $url -o /dev/null
+
+  # download with IPv4
+  curl -vsL4 -w "@$timing_file" $url -o /dev/null
+}
+
+test_download https://toolbox-data.anchore.io/grype/databases/listing.json
+
+# get the latest db file
+db_file="$(curl -sL https://toolbox-data.anchore.io/grype/databases/listing.json | jq -r '.["available"]["5"][0]["url"]')"
+
+test_download $db_file

--- a/.github/workflows/download-listing-and-db.yaml
+++ b/.github/workflows/download-listing-and-db.yaml
@@ -1,0 +1,12 @@
+name: "Download listing file and db"
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # run every 30 minutes
+  workflow_dispatch:
+
+jobs:
+  Download-listing-and-db:
+    runs-on: ubuntu-latest
+    steps:
+      - run: .github/scripts/download-listing-and-db.sh


### PR DESCRIPTION
A number of users have reported issues when attempting to download the database listing file and/or subsequent database, including:
* slowness
* 404 not found
* intermittent faillures

We are unable to reliably reproduce these problems, but occasionally see them ourselves. To attempt to get a bit more information about this, this PR adds a workflow that runs periodically so we can possibly see if certain times of day are particularly slower or more failure prone. Additionally, this checks IPv6 and IPv4 explicitly, as there may be some issues accessing these URLs with IPv6 when there is a cold cache of the database at the CDN.