### PR TITLE
chore: pass max time to download canary

### DIFF
--- a/.github/scripts/download-listing-and-db.sh
+++ b/.github/scripts/download-listing-and-db.sh
@@ -7,10 +7,10 @@ test_download() {
   url=$1
 
   # download with IPv6
-  curl -vsL6 -w "@$timing_file" $url -o /dev/null
+  curl -vsL6 -w "@$timing_file" --max-time 30 $url -o /dev/null
 
   # download with IPv4
-  curl -vsL4 -w "@$timing_file" $url -o /dev/null
+  curl -vsL4 -w "@$timing_file" --max-time 120 $url -o /dev/null
 }
 
 test_download https://toolbox-data.anchore.io/grype/databases/listing.json


### PR DESCRIPTION
This should help by highlighting slow downloads as failures in the github UI.

30 seconds to download the listing file and 120 seconds to download the database itself are the same as in Grype: https://github.com/anchore/grype/blob/57af1c34cb7db17824eac983cc6ae6945db47c88/cmd/grype/cli/options/database.go#L28-L29

Related to anchore/grype#1731