### PR TITLE
feat: grypedb should include last successful run date for each provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ process the vulnerability data. Use `-g` to generate the list of providers to pu
 **note: you can skip the `pull` step if you already have a local cache of vulnerability data (with `make download-all-provider-cache`).**
 
 The `build` command processes the cached vuln data generate a `vulnerability.db` sqlite3 file. Additionally, a `metadata.json`
-is created that is used in packaging and curation of the database file by this application and downstream consuming applications.
+is created that is used in packaging and curation of the database file by this application and downstream consuming applications
+and a `provider-metadata.json` file is created that includes the last successful run date for each provider.
 Use `-g` to generate the list of providers to pull based on the output of "vunnel list".
 
-The `package` command archives the `vulnerability.db` and `metadata.json` files into a `tar.gz` file. Additionally, a `listing.json`
+The `package` command archives the `vulnerability.db`, `metadata.json` and `provider-metadata.json` files into a `tar.gz` file. Additionally, a `listing.json`
 is generated to aid in serving one or more database archives for downstream consumption, where the consuming application should
 use the listing file to discover available archives available for download. The base URL used to create the download URL for each
 database archive is controlled by the `package.base-url` configuration option.

--- a/pkg/process/build.go
+++ b/pkg/process/build.go
@@ -43,7 +43,7 @@ func Build(cfg BuildConfig) error {
 		return err
 	}
 
-	writer, err := getWriter(cfg.SchemaVersion, cfg.Timestamp, cfg.Directory)
+	writer, err := getWriter(cfg.SchemaVersion, cfg.Timestamp, cfg.Directory, cfg.States)
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func getProcessors(schemaVersion int) ([]data.Processor, error) {
 	}
 }
 
-func getWriter(schemaVersion int, dataAge time.Time, directory string) (data.Writer, error) {
+func getWriter(schemaVersion int, dataAge time.Time, directory string, states provider.States) (data.Writer, error) {
 	switch schemaVersion {
 	case grypeDBv1.SchemaVersion:
 		return v1.NewWriter(directory, dataAge)
@@ -117,7 +117,7 @@ func getWriter(schemaVersion int, dataAge time.Time, directory string) (data.Wri
 	case grypeDBv4.SchemaVersion:
 		return v4.NewWriter(directory, dataAge)
 	case grypeDBv5.SchemaVersion:
-		return v5.NewWriter(directory, dataAge)
+		return v5.NewWriter(directory, dataAge, states)
 	default:
 		return nil, fmt.Errorf("unable to create writer: unsupported schema version: %+v", schemaVersion)
 	}


### PR DESCRIPTION
grypedb should include last successful run date for each provider. grype db build will write a new file called `provider-metadata.json` that includes the last successful run date of each provider.

This was originally intended to be implemented in the existing `metadata.json` however we do have consumers that will depend on no new fields being added (https://github.com/anchore/grype/pull/1846 for more details).

Fixes: #255 