### PR TITLE
feat: enable os vulns to have version range

### DIFF
--- a/pkg/process/v5/transformers/os/test-fixtures/mariner-range.json
+++ b/pkg/process/v5/transformers/os/test-fixtures/mariner-range.json
@@ -1,0 +1,27 @@
+[
+  {
+      "Vulnerability": {
+        "Name": "CVE-2023-29404",
+        "NamespaceName": "mariner:2.0",
+        "Description": "CVE-2023-29404 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available.",
+        "Severity": "Critical",
+        "Link": "https://nvd.nist.gov/vuln/detail/CVE-2023-29404",
+        "CVSS": [],
+        "FixedIn": [
+          {
+            "Name": "golang",
+            "NamespaceName": "mariner:2.0",
+            "VersionFormat": "rpm",
+            "Version": "0:1.20.7-1.cm2",
+            "Module": "",
+            "VendorAdvisory": {
+              "NoAdvisory": false,
+              "AdvisorySummary": []
+            },
+            "VulnerableRange": "> 0:1.19.0.cm2, < 0:1.20.7-1.cm2"
+          }
+        ],
+        "Metadata": {}
+      }
+    }
+]

--- a/pkg/process/v5/transformers/os/transform.go
+++ b/pkg/process/v5/transformers/os/transform.go
@@ -216,7 +216,7 @@ func deriveConstraintFromFix(fixVersion, vulnerabilityID string) string {
 }
 
 func enforceConstraint(fixedVersion, vulnerableRange, format, vulnerabilityID string) string {
-	if len(vulnerableRange) > 0 && !strings.HasSuffix(vulnerabilityID, "ALASKERNEL") {
+	if len(vulnerableRange) > 0 {
 		return vulnerableRange
 	}
 	fixedVersion = common.CleanConstraint(fixedVersion)

--- a/pkg/process/v5/transformers/os/transform_test.go
+++ b/pkg/process/v5/transformers/os/transform_test.go
@@ -626,6 +626,45 @@ func TestParseVulnerabilitiesEntry(t *testing.T) {
 				Description:  "A flaw was found in PostgreSQL, where some PostgreSQL extensions did not use the search_path safely in their installation script. This flaw allows an attacker with sufficient privileges to trick an administrator into executing a specially crafted script during the extension's installation or update. The highest threat from this vulnerability is to confidentiality, integrity, as well as system availability.",
 			},
 		},
+		{
+			name:       "mariner entry with version range",
+			numEntries: 1,
+			fixture:    "test-fixtures/mariner-range.json",
+			vulns: []grypeDB.Vulnerability{
+				{
+					ID:          "CVE-2023-29404",
+					PackageName: "golang",
+					Namespace:   "mariner:distro:mariner:2.0",
+					PackageQualifiers: []qualifier.Qualifier{
+						rpmmodularity.Qualifier{
+							Kind:   "rpm-modularity",
+							Module: "",
+						},
+					},
+					VersionConstraint: "> 0:1.19.0.cm2, < 0:1.20.7-1.cm2",
+					VersionFormat:     "rpm",
+					RelatedVulnerabilities: []grypeDB.VulnerabilityReference{
+						{
+							ID:        "CVE-2023-29404",
+							Namespace: "nvd:cpe",
+						},
+					},
+					Fix: grypeDB.Fix{
+						Versions: []string{"0:1.20.7-1.cm2"},
+						State:    grypeDB.FixedState,
+					},
+				},
+			},
+			metadata: grypeDB.VulnerabilityMetadata{
+				ID:           "CVE-2023-29404",
+				Namespace:    "mariner:distro:mariner:2.0",
+				DataSource:   "https://nvd.nist.gov/vuln/detail/CVE-2023-29404",
+				RecordSource: "vulnerabilities:mariner:2.0",
+				Severity:     "Critical",
+				URLs:         []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-29404"},
+				Description:  "CVE-2023-29404 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available.",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/provider/unmarshal/os_vulnerability.go
+++ b/pkg/provider/unmarshal/os_vulnerability.go
@@ -21,8 +21,9 @@ type OSFixedIn struct {
 		} `json:"AdvisorySummary"`
 		NoAdvisory bool `json:"NoAdvisory"`
 	} `json:"VendorAdvisory"`
-	Version       string `json:"Version"`
-	VersionFormat string `json:"VersionFormat"`
+	Version         string `json:"Version"`
+	VersionFormat   string `json:"VersionFormat"`
+	VulnerableRange string `json:"VulnerableRange"`
 }
 
 type OSFixedIns []OSFixedIn


### PR DESCRIPTION
The Mariner distro feed will start including version ranges in the OVAL XML. Update models and grype-db transformer to be able to handle this in version 5.

This is the other half of https://github.com/anchore/vunnel/pull/585