### PR TITLE
feat: publish latest.json listing file containing only the latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /snapshot
 metadata.json
 listing.json
+latest.json
 .vscode/
 *.db
 *.db-journal

--- a/config/grype-db-manager/include.d/distribution-production.yaml
+++ b/config/grype-db-manager/include.d/distribution-production.yaml
@@ -1,6 +1,7 @@
 # distribution:
 
 listing-file-name: listing.json
+latest-file-name: latest.json
 s3-path: grype/databases
 s3-bucket: toolbox-data.anchore.io
 aws-region: us-west-2

--- a/config/grype-db-manager/include.d/distribution-staging.yaml
+++ b/config/grype-db-manager/include.d/distribution-staging.yaml
@@ -1,6 +1,7 @@
 # distribution:
 
 listing-file-name: listing.json
+latest-file-name: latest.json
 s3-path: grype/staging-databases
 s3-bucket: toolbox-data.anchore.io
 aws-region: us-west-2

--- a/manager/src/grype_db_manager/cli/config.py
+++ b/manager/src/grype_db_manager/cli/config.py
@@ -84,6 +84,7 @@ class Validate:
 @dataclass()
 class ListingReplica:
     listing_file_name: str = "listing.json"
+    latest_file_name: str = "latest.json"
     s3_path: str | None = None
     s3_bucket: str | None = None
     aws_region: str | None = None
@@ -92,6 +93,7 @@ class ListingReplica:
 @dataclass()
 class Distribution:
     listing_file_name: str = "listing.json"
+    latest_file_name: str = "latest.json"
     s3_path: str | None = None
     s3_bucket: str | None = None
     s3_endpoint_url: str | None = None

--- a/manager/src/grype_db_manager/cli/listing.py
+++ b/manager/src/grype_db_manager/cli/listing.py
@@ -29,7 +29,7 @@ def create_listing(cfg: config.Application, listing_file: str, ignore_missing_li
     the_listing = db.listing.fetch(
         bucket=s3_bucket,
         path=s3_path,
-        filename=listing_file,
+        filename=cfg.distribution.listing_file_name,
         create_if_missing=ignore_missing_listing,
     )
 
@@ -189,7 +189,7 @@ def update_listing(ctx: click.core.Context, cfg: config.Application, dry_run: bo
 
     for listing_file_name in [cfg.distribution.listing_file_name, cfg.distribution.latest_file_name]:
         # create the historical listing file
-        click.echo(f"{Format.BOLD}Creating listing file from S3 state{Format.RESET}")
+        click.echo(f"{Format.BOLD}Creating {listing_file_name!r} file from S3 state{Format.RESET}")
         ctx.invoke(create_listing, listing_file=listing_file_name)
 
         click.echo(f"{Format.BOLD}Validating listing file {listing_file_name!r}{Format.RESET}")

--- a/manager/src/grype_db_manager/cli/listing.py
+++ b/manager/src/grype_db_manager/cli/listing.py
@@ -139,6 +139,7 @@ def validate_listing(cfg: config.Application, listing_file: str) -> None:
 
 @group.command(name="upload", help="upload a listing file to S3")
 @click.option("--ttl", "-t", "ttl_seconds", default=60 * 5, help="time to live in seconds for the listing file")
+@click.argument("listing-file")
 @click.pass_obj
 @error.handle_exception(handle=(ValueError, s3utils.CredentialsError))
 def upload_listing(cfg: config.Application, ttl_seconds: int) -> None:
@@ -196,14 +197,14 @@ def update_listing(ctx: click.core.Context, cfg: config.Application, dry_run: bo
     click.echo(f"{Format.BOLD}Creating listing files from S3 state{Format.RESET}")
     ctx.invoke(create_listing)
 
-    click.echo(f"{Format.BOLD}Validating listing file {cfg.distribution.listing_file_name!r}{Format.RESET}")
-    ctx.invoke(validate_listing, listing_file=cfg.distribution.listing_file_name)
-
-    # TODO validate latest.json
-
     for listing_file_name in [cfg.distribution.listing_file_name, cfg.distribution.latest_file_name]:
+        click.echo(f"{Format.BOLD}Validating listing file {listing_file_name!r}{Format.RESET}")
+        ctx.invoke(validate_listing, listing_file=listing_file_name)
+
         if not dry_run:
             click.echo(f"{Format.BOLD}Uploading listing file {listing_file_name!r}{Format.RESET}")
             ctx.invoke(upload_listing, listing_file=listing_file_name)
         else:
-            click.echo(f"{Format.ITALIC}Dry run! Skipping the upload of the listing file {listing_file_name!r} to S3{Format.RESET}")
+            click.echo(
+                f"{Format.ITALIC}Dry run! Skipping the upload of the listing file {listing_file_name!r} to S3{Format.RESET}"
+            )

--- a/manager/src/grype_db_manager/cli/listing.py
+++ b/manager/src/grype_db_manager/cli/listing.py
@@ -205,5 +205,5 @@ def update_listing(ctx: click.core.Context, cfg: config.Application, dry_run: bo
             ctx.invoke(upload_listing, listing_file=listing_file_name)
         else:
             click.echo(
-                f"{Format.ITALIC}Dry run! Skipping the upload of the listing file {listing_file_name!r} to S3{Format.RESET}"
+                f"{Format.ITALIC}Dry run! Skipping the upload of the listing file {listing_file_name!r} to S3{Format.RESET}",
             )

--- a/manager/src/grype_db_manager/cli/listing.py
+++ b/manager/src/grype_db_manager/cli/listing.py
@@ -17,10 +17,9 @@ def group(_: config.Application) -> None:
 
 @group.command(name="create", help="create a new listing file based on the current S3 state")
 @click.option("--ignore-missing-listing", "-i", default=False, help="ignore missing listing from S3", is_flag=True)
-@click.argument("listing-file")
 @click.pass_obj
 @error.handle_exception(handle=(ValueError,))
-def create_listing(cfg: config.Application, listing_file: str, ignore_missing_listing: bool) -> None:
+def create_listing(cfg: config.Application, ignore_missing_listing: bool) -> None:
     s3_bucket = cfg.distribution.s3_bucket
     s3_path = cfg.distribution.s3_path
     download_url_prefix = cfg.distribution.download_url_prefix
@@ -65,27 +64,34 @@ def create_listing(cfg: config.Application, listing_file: str, ignore_missing_li
     ):
         the_listing.add(entry)
 
-    if listing_file == cfg.distribution.latest_file_name:
-        # prune the listing to the latest one only
-        the_listing.prune(
-            max_age_days=0,
-            minimum_elements=1,
-        )
-    else:
-        # prune the listing to the top X many, by schema, sorted by build date
-        # note: we do not delete the entries from S3 in case they need to be referenced again
-        the_listing.prune(
-            max_age_days=distribution.MAX_DB_AGE,
-            minimum_elements=distribution.MINIMUM_DB_COUNT,
-        )
+    # prune the listing to the top X many, by schema, sorted by build date
+    # note: we do not delete the entries from S3 in case they need to be referenced again
+    the_listing.prune(
+        max_age_days=distribution.MAX_DB_AGE,
+        minimum_elements=distribution.MINIMUM_DB_COUNT,
+    )
 
     total_entries = sum([len(v) for k, v in the_listing.available.items()])
-    logging.info(f"wrote {total_entries} total database entries to the listing")
+    logging.info(f"wrote {total_entries} total database entries to {cfg.distribution.listing_file_name}")
 
-    with open(listing_file, "w") as f:
+    with open(cfg.distribution.listing_file_name, "w") as f:
         f.write(the_listing.to_json())
 
-    click.echo(listing_file)
+    click.echo(cfg.distribution.listing_file_name)
+
+    # prune the listing to the latest one only to write a latest.json
+    the_listing.prune(
+        max_age_days=0,
+        minimum_elements=1,
+    )
+
+    total_entries = sum([len(v) for k, v in the_listing.available.items()])
+    logging.info(f"wrote {total_entries} total database entries to {cfg.distribution.latest_file_name}")
+
+    with open(cfg.distribution.latest_file_name, "w") as f:
+        f.write(the_listing.to_json())
+
+    click.echo(cfg.distribution.latest_file_name)
 
 
 @group.command(name="validate", help="validate all supported schema versions are expressed in the listing file")
@@ -133,47 +139,47 @@ def validate_listing(cfg: config.Application, listing_file: str) -> None:
 
 @group.command(name="upload", help="upload a listing file to S3")
 @click.option("--ttl", "-t", "ttl_seconds", default=60 * 5, help="time to live in seconds for the listing file")
-@click.argument("listing-file")
 @click.pass_obj
 @error.handle_exception(handle=(ValueError, s3utils.CredentialsError))
-def upload_listing(cfg: config.Application, listing_file: str, ttl_seconds: int) -> None:
+def upload_listing(cfg: config.Application, ttl_seconds: int) -> None:
     if cfg.assert_aws_credentials:
         s3utils.check_credentials()
 
     s3_bucket = cfg.distribution.s3_bucket
     s3_path = cfg.distribution.s3_path
 
-    with open(listing_file) as f:
-        the_listing = db.Listing.from_json(f.read())
+    for listing_file in [cfg.distribution.listing_file_name, cfg.distribution.latest_file_name]:
+        with open(listing_file) as f:
+            the_listing = db.Listing.from_json(f.read())
 
-    # upload the primary listing file
-    s3utils.upload(
-        bucket=s3_bucket,
-        key=the_listing.url(s3_path, listing_file),
-        contents=the_listing.to_json(),
-        CacheControl=f"public,max-age={ttl_seconds}",
-    )
-
-    click.echo(f"{listing_file} uploaded to s3://{s3_bucket}/{s3_path}")
-
-    # upload to replicas
-    for replica in cfg.distribution.listing_replicas:
-        replica_s3_bucket = replica.s3_bucket or s3_bucket
-        replica_s3_path = replica.s3_path or s3_path
-        replica_filename = replica.listing_file_name or listing_file
-
-        if not replica_s3_bucket or not replica_s3_path:
-            logging.warning(f"skipping replica upload for {replica} because s3_bucket and s3_path are required")
-            continue
-
+        # upload the listing file
         s3utils.upload(
-            bucket=replica_s3_bucket,
-            key=the_listing.url(replica_s3_path, replica_filename),
+            bucket=s3_bucket,
+            key=the_listing.url(s3_path, listing_file),
             contents=the_listing.to_json(),
             CacheControl=f"public,max-age={ttl_seconds}",
         )
 
-        click.echo(f"{listing_file} uploaded to s3://{replica_s3_bucket}/{replica_s3_path}")
+        click.echo(f"{listing_file} uploaded to s3://{s3_bucket}/{s3_path}")
+
+        # upload to replicas
+        for replica in cfg.distribution.listing_replicas:
+            replica_s3_bucket = replica.s3_bucket or s3_bucket
+            replica_s3_path = replica.s3_path or s3_path
+            replica_filename = replica.listing_file_name or listing_file
+
+            if not replica_s3_bucket or not replica_s3_path:
+                logging.warning(f"skipping replica upload for {replica} because s3_bucket and s3_path are required")
+                continue
+
+            s3utils.upload(
+                bucket=replica_s3_bucket,
+                key=the_listing.url(replica_s3_path, replica_filename),
+                contents=the_listing.to_json(),
+                CacheControl=f"public,max-age={ttl_seconds}",
+            )
+
+            click.echo(f"{replica_filename} uploaded to s3://{replica_s3_bucket}/{replica_s3_path}")
 
 
 @group.command(name="update", help="recreate a listing based off of S3 state, validate it, and upload it")
@@ -187,16 +193,17 @@ def update_listing(ctx: click.core.Context, cfg: config.Application, dry_run: bo
     elif cfg.assert_aws_credentials:
         s3utils.check_credentials()
 
+    click.echo(f"{Format.BOLD}Creating listing files from S3 state{Format.RESET}")
+    ctx.invoke(create_listing)
+
+    click.echo(f"{Format.BOLD}Validating listing file {cfg.distribution.listing_file_name!r}{Format.RESET}")
+    ctx.invoke(validate_listing, listing_file=cfg.distribution.listing_file_name)
+
+    # TODO validate latest.json
+
     for listing_file_name in [cfg.distribution.listing_file_name, cfg.distribution.latest_file_name]:
-        # create the historical listing file
-        click.echo(f"{Format.BOLD}Creating {listing_file_name!r} file from S3 state{Format.RESET}")
-        ctx.invoke(create_listing, listing_file=listing_file_name)
-
-        click.echo(f"{Format.BOLD}Validating listing file {listing_file_name!r}{Format.RESET}")
-        ctx.invoke(validate_listing, listing_file=listing_file_name)
-
         if not dry_run:
             click.echo(f"{Format.BOLD}Uploading listing file {listing_file_name!r}{Format.RESET}")
             ctx.invoke(upload_listing, listing_file=listing_file_name)
         else:
-            click.echo(f"{Format.ITALIC}Dry run! Skipping the upload of the listing file to S3{Format.RESET}")
+            click.echo(f"{Format.ITALIC}Dry run! Skipping the upload of the listing file {listing_file_name!r} to S3{Format.RESET}")

--- a/manager/src/grype_db_manager/db/listing.py
+++ b/manager/src/grype_db_manager/db/listing.py
@@ -224,7 +224,7 @@ def _http_server(directory: str) -> Iterator[str]:
     try:
         yield listing_url
     finally:
-        httpd.server_close()
+        httpd.shutdown()
         pass
 
 

--- a/manager/src/grype_db_manager/db/listing.py
+++ b/manager/src/grype_db_manager/db/listing.py
@@ -209,11 +209,12 @@ def _http_server(directory: str) -> Iterator[str]:
     url = f"http://{server_address[0]}:{server_address[1]}"
     listing_url = f"{url}/{LISTING_FILENAME}"
 
+    httpd = HTTPServer(
+        server_address,
+        functools.partial(SimpleHTTPRequestHandler, directory=directory),
+    )
+
     def serve() -> None:
-        httpd = HTTPServer(
-            server_address,
-            functools.partial(SimpleHTTPRequestHandler, directory=directory),
-        )
         logging.info(f"starting test server at {url}")
         httpd.serve_forever()
 
@@ -223,6 +224,7 @@ def _http_server(directory: str) -> Iterator[str]:
     try:
         yield listing_url
     finally:
+        httpd.server_close()
         pass
 
 

--- a/manager/tests/cli/.grype-db-manager.yaml
+++ b/manager/tests/cli/.grype-db-manager.yaml
@@ -16,6 +16,7 @@ grype-db:
 
 distribution:
   listing-file-name: listing.json
+  latest-file-name: latest.json
   s3-path: grype/databases
   # note: we are using localstack for testing, so the bucket name is arbitrary
   s3-bucket: testbucket

--- a/manager/tests/unit/cli/fixtures/config/full.yaml
+++ b/manager/tests/unit/cli/fixtures/config/full.yaml
@@ -16,6 +16,7 @@ grype-db:
 
 distribution:
   listing-file-name: listing.json
+  latest-file-name: latest.json
   s3-path: grype/databases
   s3-bucket: testbucket
   aws-region: us-west-2
@@ -24,6 +25,7 @@ distribution:
   listing_replicas:
     - awsRegion: us-west-2
       listingFileName: listing.json
+      latestFileName: latest.json
       s3Bucket: testbucket
       s3Path: grype/databases
       

--- a/manager/tests/unit/cli/fixtures/db/upload-test-config.yaml
+++ b/manager/tests/unit/cli/fixtures/db/upload-test-config.yaml
@@ -1,5 +1,6 @@
 distribution:
   listing-file-name: listing.json
+  latest-file-name: latest.json
   s3-path: grype/databases
   # note: we are using localstack for testing, so the bucket name is arbitrary
   s3-bucket: testbucket

--- a/manager/tests/unit/cli/fixtures/listing/create-all-exists/.grype-db-manager.yaml
+++ b/manager/tests/unit/cli/fixtures/listing/create-all-exists/.grype-db-manager.yaml
@@ -3,6 +3,7 @@ log:
 
 distribution:
   listing-file-name: listing.json
+  latest-file-name: latest.json
   s3-path: grype/databases
   s3-bucket: testbucket
   aws-region: us-west-2

--- a/manager/tests/unit/cli/fixtures/listing/create-all-exists/expected-latest.json
+++ b/manager/tests/unit/cli/fixtures/listing/create-all-exists/expected-latest.json
@@ -1,0 +1,44 @@
+{
+  "available": {
+    "1": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:35ac11b43eb8b1058d9038ce28a5901f2dd5b33223a85df60a739421cfea9d2e",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v1_2023-08-10T01:32:21Z_993f1c0a71d3cedd726a.tar.gz",
+        "version": 1
+      }
+    ],
+    "2": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:1ce996f58b8a0cbb274737da34b9435470ffe42dd3689c06027cc18940206b07",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v2_2023-08-10T01:32:21Z_89457f888a3d4a11f827.tar.gz",
+        "version": 2
+      }
+    ],
+    "3": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:092c5661622a6d733f5bdf3cdfb5a8f966e88e443914794b038c949777efbb43",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v3_2023-08-10T01:32:21Z_dcee097f2c55f5663d12.tar.gz",
+        "version": 3
+      }
+    ],
+    "4": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:233a1c70b3021061a615382d66de5c20cf334c693c025eb5885a623fe9d08d5b",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v4_2023-08-10T01:32:21Z_2926495f3f0dd45c48ba.tar.gz",
+        "version": 4
+      }
+    ],
+    "5": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:78045f3ed82435569a3681bc1da3c1e1a5cf80ac2536580dee35c8aa8e7f2cf6",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v5_2023-08-10T01:32:21Z_7bf3acd8d0424bb6e3d9.tar.gz",
+        "version": 5
+      }
+    ]
+  }
+}

--- a/manager/tests/unit/cli/fixtures/listing/create-new-db/.grype-db-manager.yaml
+++ b/manager/tests/unit/cli/fixtures/listing/create-new-db/.grype-db-manager.yaml
@@ -3,6 +3,7 @@ log:
 
 distribution:
   listing-file-name: listing.json
+  latest-file-name: latest.json
   s3-path: grype/databases
   s3-bucket: testbucket
   aws-region: us-west-2

--- a/manager/tests/unit/cli/fixtures/listing/create-new-db/expected-latest.json
+++ b/manager/tests/unit/cli/fixtures/listing/create-new-db/expected-latest.json
@@ -34,9 +34,9 @@
     ],
     "5": [
       {
-        "built": "2023-08-11T02:13:23Z",
-        "checksum": "sha256:1b66fce9af47877f18414cde4db8437e03bf2951f079916dc1882626b69976cf",
-        "url": "http://localhost:4566/testbucket/grype/databases/vulnerability-db_v5_2023-08-11T02:13:23Z_e95fbb61d7b141d7256b.tar.gz",
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:78045f3ed82435569a3681bc1da3c1e1a5cf80ac2536580dee35c8aa8e7f2cf6",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v5_2023-08-10T01:32:21Z_7bf3acd8d0424bb6e3d9.tar.gz",
         "version": 5
       }
     ]

--- a/manager/tests/unit/cli/fixtures/listing/create-new-db/expected-latest.json
+++ b/manager/tests/unit/cli/fixtures/listing/create-new-db/expected-latest.json
@@ -1,0 +1,44 @@
+{
+  "available": {
+    "1": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:35ac11b43eb8b1058d9038ce28a5901f2dd5b33223a85df60a739421cfea9d2e",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v1_2023-08-10T01:32:21Z_993f1c0a71d3cedd726a.tar.gz",
+        "version": 1
+      }
+    ],
+    "2": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:1ce996f58b8a0cbb274737da34b9435470ffe42dd3689c06027cc18940206b07",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v2_2023-08-10T01:32:21Z_89457f888a3d4a11f827.tar.gz",
+        "version": 2
+      }
+    ],
+    "3": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:092c5661622a6d733f5bdf3cdfb5a8f966e88e443914794b038c949777efbb43",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v3_2023-08-10T01:32:21Z_dcee097f2c55f5663d12.tar.gz",
+        "version": 3
+      }
+    ],
+    "4": [
+      {
+        "built": "2023-08-10T01:32:21Z",
+        "checksum": "sha256:233a1c70b3021061a615382d66de5c20cf334c693c025eb5885a623fe9d08d5b",
+        "url": "https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v4_2023-08-10T01:32:21Z_2926495f3f0dd45c48ba.tar.gz",
+        "version": 4
+      }
+    ],
+    "5": [
+      {
+        "built": "2023-08-11T02:13:23Z",
+        "checksum": "sha256:1b66fce9af47877f18414cde4db8437e03bf2951f079916dc1882626b69976cf",
+        "url": "http://localhost:4566/testbucket/grype/databases/vulnerability-db_v5_2023-08-11T02:13:23Z_e95fbb61d7b141d7256b.tar.gz",
+        "version": 5
+      }
+    ]
+  }
+}

--- a/manager/tests/unit/cli/test_config.py
+++ b/manager/tests/unit/cli/test_config.py
@@ -49,6 +49,7 @@ data:
 distribution:
   awsRegion: null
   downloadUrlPrefix: null
+  latestFileName: latest.json
   listingFileName: listing.json
   listingReplicas: []
   s3Bucket: null
@@ -97,9 +98,11 @@ data:
 distribution:
   awsRegion: us-west-2
   downloadUrlPrefix: http://localhost:4566/testbucket
+  latestFileName: latest.json
   listingFileName: listing.json
   listingReplicas:
     - awsRegion: us-west-2
+      latestFileName: latest.json
       listingFileName: listing.json
       s3Bucket: testbucket
       s3Path: grype/databases

--- a/manager/tests/unit/cli/test_listing.py
+++ b/manager/tests/unit/cli/test_listing.py
@@ -29,22 +29,24 @@ from grype_db_manager.cli import config
 
 @pytest.fixture
 def listing_s3_mock(redact_aws_credentials):
-    def run(listing_file, dir_with_config: str, skip_db_in_s3: list[str] = None, extra_dbs: list[str] = None):
+    def run(dir_with_config: str, skip_db_in_s3: list[str] = None, extra_dbs: list[str] = None):
         if not skip_db_in_s3:
             skip_db_in_s3 = []
 
         if not extra_dbs:
             extra_dbs = []
 
+        listing_file_name = "listing.json"
+
         with utils.set_directory(dir_with_config):
             cfg = config.load()
-            if os.path.exists(listing_file):
-                os.remove(listing_file)
+            if os.path.exists(listing_file_name):
+                os.remove(listing_file_name)
 
         bucket = cfg.distribution.s3_bucket
         path = cfg.distribution.s3_path
 
-        listing_path = os.path.join(path, listing_file)
+        listing_path = os.path.join(path, listing_file_name)
 
         # add the input listing file to the bucket
         input_listing_path = os.path.join(dir_with_config, "input-listing.json")
@@ -165,7 +167,7 @@ def test_create_listing(
 ):
     # contains an application config file
     config_dir_path = test_dir_path(f"fixtures/listing/{case_dir}")
-    listing_s3_mock(listing_file, config_dir_path, extra_dbs=extra_dbs)
+    listing_s3_mock(config_dir_path, extra_dbs=extra_dbs)
     mock_file_age.return_value = 42  # needs to be less than distribution.MAX_DB_AGE
 
     with utils.set_directory(config_dir_path):


### PR DESCRIPTION
This PR adds a secondary listing file, `latest.json`, which should be published along with the `listing.json` so we may be able to reduce the amount of data transfer used by invocations of Grype which only need the latest db, but not any historical records, which is almost every invocation of grype.