### PR TITLE
chore: shrink listing file to speed download times

### DIFF
--- a/manager/src/grype_db_manager/distribution.py
+++ b/manager/src/grype_db_manager/distribution.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
 DB_SUFFIXES = {".tar.gz", ".tar.zst"}
-MAX_DB_AGE = 7  # old db listings are making the file large and slowing download times
-MINIMUM_DB_COUNT = 2  # always include at least 2 databases, no matter how old
+MAX_DB_AGE = 3  # old db listings are making the file large and slowing download times
+MINIMUM_DB_COUNT = 3  # always include at least 2 databases, no matter how old
 
 
 def listing_entries_dbs_in_s3(

--- a/manager/src/grype_db_manager/distribution.py
+++ b/manager/src/grype_db_manager/distribution.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
 DB_SUFFIXES = {".tar.gz", ".tar.zst"}
-MAX_DB_AGE = 120  # ~4 months in days
-MINIMUM_DB_COUNT = MAX_DB_AGE  # number of db entries per schema
+MAX_DB_AGE = 7  # old db listings are making the file large and slowing download times
+MINIMUM_DB_COUNT = 2  # always include at least 2 databases, no matter how old
 
 
 def listing_entries_dbs_in_s3(

--- a/manager/tests/unit/cli/test_listing.py
+++ b/manager/tests/unit/cli/test_listing.py
@@ -137,7 +137,7 @@ def test_create_listing(
     # contains an application config file
     config_dir_path = test_dir_path(f"fixtures/listing/{case_dir}")
     listing_s3_mock(config_dir_path, extra_dbs=extra_dbs)
-    mock_file_age.return_value = 42  # needs to be less than distribution.MAX_DB_AGE
+    mock_file_age.return_value = 2  # needs to be less than distribution.MAX_DB_AGE
 
     with utils.set_directory(config_dir_path):
         with open("expected-listing.json") as f:


### PR DESCRIPTION
The listing file is large enough and frequently enough downloaded that we expect better performance with a smaller listing database file.

See anchore/grype#1731