### PR TITLE
fix: change workflow script from docker-compose to docker compose

### DIFF
--- a/manager/tests/cli/workflow-3-update-listing.sh
+++ b/manager/tests/cli/workflow-3-update-listing.sh
@@ -23,7 +23,7 @@ rm -rf $BIN_DIR
 curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b $BIN_DIR $GRYPE_VERSION
 
 pushd s3-mock
-docker-compose up -d
+docker compose up -d
 python setup-workflow-3.py
 popd
 
@@ -58,7 +58,7 @@ assert_contains $(last_stdout_file) "CVE-2016-2148"
 ### End of testing ########################
 
 pushd s3-mock
-docker-compose down -t 1 -v
+docker compose down -t 1 -v
 popd
 
 end_testing

--- a/manager/tests/cli/workflow-4-full-publish.sh
+++ b/manager/tests/cli/workflow-4-full-publish.sh
@@ -31,7 +31,7 @@ make clean-manager
 make cli-test-data/vunnel/oracle
 
 pushd s3-mock
-docker-compose up -d
+docker compose up -d
 python setup-workflow-4.py
 popd
 
@@ -78,7 +78,7 @@ assert_contains $(last_stdout_file) "ELSA-2021-9591"
 ### End of testing ########################
 
 pushd s3-mock
-docker-compose down -t 1 -v
+docker compose down -t 1 -v
 popd
 
 end_testing


### PR DESCRIPTION
Apparently "docker-compose" is no longer on PATH in GH actions runners. Switch to "docker compose".

Fixes #350 