### PR TITLE
doc: Updates for the Slack to Discourse migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 contact_links:
 
-  - name: Join the Slack community 💬
-    # link to our community Slack registration page
-    url: https://anchore.com/slack
+  - name: Join our Discourse community 💬
+    # link to our community Discourse site
+    url: https://anchore.com/discourse
     about: 'Come chat with us! Ask for help, join our software development efforts, or just give us feedback!'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # grype-db
-Application to create a grype vulnerability database from upstream vulnerability data sources.
 
+**Application to create a [Grype](https://github.com/anchore/grype) vulnerability database from upstream vulnerability data sources.**
+
+[![GitHub release](https://img.shields.io/github/release/anchore/grype-db.svg)](https://github.com/anchore/grype-db/releases/latest)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/grype-db/blob/main/LICENSE)
+[![Join our Discourse](https://img.shields.io/badge/Discourse-Join-blue?logo=discourse)](https://anchore.com/discourse)
 
 ## Installation
 


### PR DESCRIPTION
This updates the links to the community Slack to Discourse links.