### PR TITLE
Sync listing.json from R2 to S3

### DIFF
--- a/.github/workflows/copy-listing-from-r2.yaml
+++ b/.github/workflows/copy-listing-from-r2.yaml
@@ -2,19 +2,9 @@ name: 'Sync listing from R2 to S3'
 on:
   # allow for kicking off DB builds manually
   workflow_dispatch:
-    # TODO: delete me
-    inputs:
-      enabled:
-        description: "sync the Grype DB listing file from R2 to S3"
-        type: boolean
-        required: true
-        default: false
 
   # allow invoking from another workflow
   workflow_call:
-
-  # TODO: remove me
-  push:
 
 env:
   CGO_ENABLED: "0"
@@ -24,9 +14,6 @@ env:
 jobs:
   sync-listing-file:
     name: "Sync listing file"
-    
-    # TODO: delete me
-    if: ${{ github.event.inputs.enabled == 'true' }}
 
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/copy-listing-from-r2.yaml
+++ b/.github/workflows/copy-listing-from-r2.yaml
@@ -1,0 +1,60 @@
+name: 'Sync listing from R2 to S3'
+on:
+  # allow for kicking off DB builds manually
+  workflow_dispatch:
+    # TODO: delete me
+    inputs:
+      enabled:
+        description: "sync the Grype DB listing file from R2 to S3"
+        type: boolean
+        required: true
+        default: false
+
+  # allow invoking from another workflow
+  workflow_call:
+
+  # TODO: remove me
+  push:
+
+env:
+  CGO_ENABLED: "0"
+  SLACK_NOTIFICATIONS: true
+  FORCE_COLOR: true
+
+jobs:
+  sync-listing-file:
+    name: "Sync listing file"
+    
+    # TODO: delete me
+    if: ${{ github.event.inputs.enabled == 'true' }}
+
+    runs-on: ubuntu-22.04
+    steps:
+
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
+
+      - name: Download the R2 listing file
+        run: curl --fail -O https://grype.anchore.io/databases/listing.json
+
+      - name: Upload listing file
+        run: |
+          poetry run \
+            grype-db-manager \
+              -c ./config/grype-db-manager/publish-production.yaml \
+                listing upload listing.json
+        env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
+
+      - uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 #v3.16.2
+        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+        with:
+          status: ${{ job.status }}
+          fields: workflow,eventName,job
+          text: Sync of the Grype DB listing file from R2 to S3 has failed
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -145,3 +145,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
         if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+
+  sync-listing-file-to-s3:
+    name: "Sync listing file to S3"
+    needs:
+      - publish-listing-file
+    uses: ./.github/workflows/copy-listing-from-r2.yaml
+    secrets: inherit

--- a/.github/workflows/daily-db-publisher.yaml
+++ b/.github/workflows/daily-db-publisher.yaml
@@ -100,40 +100,59 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
         if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
 
-  publish-listing-file:
-    # fun! https://github.com/actions/runner/issues/491#issuecomment-850884422
-    # essentially even if the workflow dispatch job is skipping steps, we still want to run this step.
-    # however, if not running from a workflow dispatch then we want the job ordering to be honored.
-    # also...
-    # note about workflow dispatch inputs and booleans:
-    # a) booleans come across as string types :(
-    # b) if not using workflow_dispatch the default values are empty, which means we want these to effectively evaluate to true (so only check the negative case)
-    if: |
-      always() &&
-      (needs.generate-and-publish-dbs.result == 'success' || needs.generate-and-publish-dbs.result == 'skipped') &&
-      github.event.inputs.publish-listing != 'false'
+  # TODO: rollback uncomment me and comment out the notify job
+  # publish-listing-file:
+  #   # fun! https://github.com/actions/runner/issues/491#issuecomment-850884422
+  #   # essentially even if the workflow dispatch job is skipping steps, we still want to run this step.
+  #   # however, if not running from a workflow dispatch then we want the job ordering to be honored.
+  #   # also...
+  #   # note about workflow dispatch inputs and booleans:
+  #   # a) booleans come across as string types :(
+  #   # b) if not using workflow_dispatch the default values are empty, which means we want these to effectively evaluate to true (so only check the negative case)
+  #   if: |
+  #     always() &&
+  #     (needs.generate-and-publish-dbs.result == 'success' || needs.generate-and-publish-dbs.result == 'skipped') &&
+  #     github.event.inputs.publish-listing != 'false'
 
+  #   name: "Publish listing file"
+  #   needs: generate-and-publish-dbs
+  #   runs-on: ubuntu-22.04-4core-16gb
+  #   steps:
+
+  #     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+  #       with:
+  #         submodules: true
+
+  #     - name: Bootstrap environment
+  #       uses: ./.github/actions/bootstrap
+
+  #     - name: Publish listing file
+  #       run: |
+  #         poetry run \
+  #           grype-db-manager \
+  #             -c ./config/grype-db-manager/publish-production.yaml \
+  #               listing update
+  #       env:
+  #           AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
+  #           AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
+
+  #     - uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 #v3.16.2
+  #       with:
+  #         status: ${{ job.status }}
+  #         fields: workflow,eventName,job
+  #         text: Publishing the Grype DB listing file has failed
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+  #       if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+
+
+  notify:
+    if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
     name: "Publish listing file"
     needs: generate-and-publish-dbs
-    runs-on: ubuntu-22.04-4core-16gb
+    runs-on: ubuntu-22.04
     steps:
-
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
-        with:
-          submodules: true
-
-      - name: Bootstrap environment
-        uses: ./.github/actions/bootstrap
-
-      - name: Publish listing file
-        run: |
-          poetry run \
-            grype-db-manager \
-              -c ./config/grype-db-manager/publish-production.yaml \
-                listing update
-        env:
-            AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
 
       - uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 #v3.16.2
         with:
@@ -142,4 +161,3 @@ jobs:
           text: Publishing the Grype DB listing file has failed
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}

--- a/config/grype-db-manager/publish-production-r2.yaml
+++ b/config/grype-db-manager/publish-production-r2.yaml
@@ -7,3 +7,5 @@ grype-db: !include config/grype-db-manager/include.d/grype-db-local-build-r2.yam
 distribution: !include config/grype-db-manager/include.d/distribution-production-r2.yaml
 
 validate: !include config/grype-db-manager/include.d/validate.yaml
+
+assert-aws-credentials: false


### PR DESCRIPTION
This adds a sync job from R2 to S3 to update the listing file so that all users are hitting the R2 bucket not S3. In the near future after a soak period we'll turn down the s3 workflow entirely.