### PR TITLE
Add ability to skip listing validations

### DIFF
--- a/.grype-db-manager.yaml
+++ b/.grype-db-manager.yaml
@@ -7,5 +7,3 @@ grype-db: !include config/grype-db-manager/include.d/grype-db-local-build.yaml
 #  ...
 
 validate: !include config/grype-db-manager/include.d/validate.yaml
-
-assert_aws_credentials: false

--- a/.grype-db-manager.yaml
+++ b/.grype-db-manager.yaml
@@ -7,3 +7,5 @@ grype-db: !include config/grype-db-manager/include.d/grype-db-local-build.yaml
 #  ...
 
 validate: !include config/grype-db-manager/include.d/validate.yaml
+
+assert_aws_credentials: false

--- a/manager/src/grype_db_manager/cli/listing.py
+++ b/manager/src/grype_db_manager/cli/listing.py
@@ -173,10 +173,11 @@ def upload_listing(cfg: config.Application, listing_file: str, ttl_seconds: int)
 
 @group.command(name="update", help="recreate a listing based off of S3 state, validate it, and upload it")
 @click.option("--dry-run", "-d", default=False, help="do not upload the listing file to S3", is_flag=True)
+@click.option("--skip-validate", default=False, help="skip validation of the listing file", is_flag=True)
 @click.pass_obj
 @click.pass_context
 @error.handle_exception(handle=(ValueError, s3utils.CredentialsError))
-def update_listing(ctx: click.core.Context, cfg: config.Application, dry_run: bool) -> None:
+def update_listing(ctx: click.core.Context, cfg: config.Application, dry_run: bool, skip_validate: bool) -> None:
     if dry_run:
         click.echo(f"{Format.ITALIC}Dry run! Will skip uploading the listing file to S3{Format.RESET}")
     elif cfg.assert_aws_credentials:
@@ -185,8 +186,11 @@ def update_listing(ctx: click.core.Context, cfg: config.Application, dry_run: bo
     click.echo(f"{Format.BOLD}Creating listing file from S3 state{Format.RESET}")
     listing_file_name = ctx.invoke(create_listing)
 
-    click.echo(f"{Format.BOLD}Validating listing file {listing_file_name!r}{Format.RESET}")
-    ctx.invoke(validate_listing, listing_file=listing_file_name)
+    if not skip_validate:
+        click.echo(f"{Format.BOLD}Validating listing file {listing_file_name!r}{Format.RESET}")
+        ctx.invoke(validate_listing, listing_file=listing_file_name)
+    else:
+        click.echo(f"{Format.ITALIC}Skipping the validation of the listing file{Format.RESET}")
 
     if not dry_run:
         click.echo(f"{Format.BOLD}Uploading listing file {listing_file_name!r}{Format.RESET}")

--- a/manager/src/grype_db_manager/db/listing.py
+++ b/manager/src/grype_db_manager/db/listing.py
@@ -273,7 +273,7 @@ def smoke_test(
         installation_path = os.path.join(tempdir, "grype-install")
 
         # way too verbose!
-        # logging.info(listing_contents)
+        logging.info(listing_contents)
         with open(os.path.join(tempdir, LISTING_FILENAME), "w") as f:
             f.write(listing_contents)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1415,8 +1415,8 @@ tabulate = "^0.9.0"
 [package.source]
 type = "git"
 url = "https://github.com/anchore/yardstick"
-reference = "8d86e14af1ecb6ffb72ced28a1f7cdea629319cc"
-resolved_reference = "8d86e14af1ecb6ffb72ced28a1f7cdea629319cc"
+reference = "54fa85dc38e3446bc9c6660ca3117a8c87391915"
+resolved_reference = "54fa85dc38e3446bc9c6660ca3117a8c87391915"
 
 [[package]]
 name = "zipp"
@@ -1497,4 +1497,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<=3.13"
-content-hash = "bb164ba1cc45b8948d189255ddec9e9b10b6f53acd4b9a187363ea7b445dad11"
+content-hash = "2a3c853eb0d6618c11e9a56589b4d89b2118cc8feb3a445f9c4c8362c4735e2d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -521,13 +521,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "8.2.0"
+version = "7.2.1"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-8.2.0-py3-none-any.whl", hash = "sha256:11901fa0c2f97919b288679932bb64febaeacf289d18ac84dd68cb2e74213369"},
-    {file = "importlib_metadata-8.2.0.tar.gz", hash = "sha256:72e8d4399996132204f9a16dcc751af254a48f8d1b20b9ff0f98d4a8f901e73d"},
+    {file = "importlib_metadata-7.2.1-py3-none-any.whl", hash = "sha256:ffef94b0b66046dd8ea2d619b701fe978d9264d38f3998bc4c27ec3b146a87c8"},
+    {file = "importlib_metadata-7.2.1.tar.gz", hash = "sha256:509ecb2ab77071db5137c655e24ceb3eee66e7bbc6574165d0d114d9fc4bbe68"},
 ]
 
 [package.dependencies]
@@ -1402,7 +1402,7 @@ Colr = "^0.9.1"
 dataclass-wizard = "^0.22.3"
 dataclasses-json = "^0.6.7"
 GitPython = "^3.1.43"
-importlib-metadata = "^8.2.0"
+importlib-metadata = ">=7.0.1,<8.0.0"
 mergedeep = "^1.3.4"
 omitempty = "^0.1.1"
 prompt-toolkit = "^3.0.47"
@@ -1415,8 +1415,8 @@ tabulate = "^0.9.0"
 [package.source]
 type = "git"
 url = "https://github.com/anchore/yardstick"
-reference = "54fa85dc38e3446bc9c6660ca3117a8c87391915"
-resolved_reference = "54fa85dc38e3446bc9c6660ca3117a8c87391915"
+reference = "9dba1cd8139bbc743432023c37057c887ec98e44"
+resolved_reference = "9dba1cd8139bbc743432023c37057c887ec98e44"
 
 [[package]]
 name = "zipp"
@@ -1497,4 +1497,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<=3.13"
-content-hash = "2a3c853eb0d6618c11e9a56589b4d89b2118cc8feb3a445f9c4c8362c4735e2d"
+content-hash = "1f040474adf22d90417c36b066d9f0a3ef055587222330fbc7b3a79d7730f4e8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1415,8 +1415,8 @@ tabulate = "^0.9.0"
 [package.source]
 type = "git"
 url = "https://github.com/anchore/yardstick"
-reference = "9dba1cd8139bbc743432023c37057c887ec98e44"
-resolved_reference = "9dba1cd8139bbc743432023c37057c887ec98e44"
+reference = "8ef84656c6618292110c47fbb8805d78fc7b235d"
+resolved_reference = "8ef84656c6618292110c47fbb8805d78fc7b235d"
 
 [[package]]
 name = "zipp"
@@ -1497,4 +1497,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<=3.13"
-content-hash = "1f040474adf22d90417c36b066d9f0a3ef055587222330fbc7b3a79d7730f4e8"
+content-hash = "943f0065c9a9329e092b695fd19a660059c1753f70790eb53fe0cf48e4dcab75"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ zstandard = ">=0.21.0, <1"
 colorlog = "^6.7.0"
 mergedeep = "^1.3.4"
 pyyaml = ">=5.0.1, <7"
-yardstick = {git = "https://github.com/anchore/yardstick", rev = "9dba1cd8139bbc743432023c37057c887ec98e44"}
+yardstick = {git = "https://github.com/anchore/yardstick", rev = "8ef84656c6618292110c47fbb8805d78fc7b235d"}
 #yardstick = {path = "../yardstick", develop = true}
 colr = "^0.9.1"
 pyyaml-include = "^1.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ zstandard = ">=0.21.0, <1"
 colorlog = "^6.7.0"
 mergedeep = "^1.3.4"
 pyyaml = ">=5.0.1, <7"
-yardstick = {git = "https://github.com/anchore/yardstick", rev = "8d86e14af1ecb6ffb72ced28a1f7cdea629319cc"}
+yardstick = {git = "https://github.com/anchore/yardstick", rev = "54fa85dc38e3446bc9c6660ca3117a8c87391915"}
 #yardstick = {path = "../yardstick", develop = true}
 colr = "^0.9.1"
 pyyaml-include = "^1.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ zstandard = ">=0.21.0, <1"
 colorlog = "^6.7.0"
 mergedeep = "^1.3.4"
 pyyaml = ">=5.0.1, <7"
-yardstick = {git = "https://github.com/anchore/yardstick", rev = "54fa85dc38e3446bc9c6660ca3117a8c87391915"}
+yardstick = {git = "https://github.com/anchore/yardstick", rev = "9dba1cd8139bbc743432023c37057c887ec98e44"}
 #yardstick = {path = "../yardstick", develop = true}
 colr = "^0.9.1"
 pyyaml-include = "^1.3.1"


### PR DESCRIPTION
Folks may want to craft and update a listing file directly out of an s3 bucket that is not publicly accessible yet, which means that validations should be skipped.