### PR TITLE
chore: enable R2 publishing schedule

### DIFF
--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -15,8 +15,8 @@ on:
         default: true
 
   # run 4 AM (UTC) daily
-  # schedule:
-  #  - cron:  '0 4 * * *'
+  schedule:
+    - cron:  '0 4 * * *'
 
 env:
   CGO_ENABLED: "0"


### PR DESCRIPTION
This PR enables the R2 publishing to run daily.