### PR TITLE
fix: query for ID before close but compute checksum after

### DIFF
--- a/config/grype/acceptance.yaml
+++ b/config/grype/acceptance.yaml
@@ -1,0 +1,2 @@
+db:
+  validate-by-hash-on-start: true

--- a/manager/src/grype_db_manager/cli/db.py
+++ b/manager/src/grype_db_manager/cli/db.py
@@ -132,6 +132,20 @@ def validate_db(
     result_set = "db-validation"
 
     yardstick_cfg = ycfg.Application(
+        profiles=ycfg.Profiles(
+            data={
+                "grype": {
+                    "acceptance": {
+                        "config_path": "config/grype/acceptance.yaml",
+                    },
+                },
+                "grype[custom-db]": {
+                    "acceptance": {
+                        "config_path": "config/grype/acceptance.yaml",
+                    },
+                },
+            },
+        ),
         store_root=cfg.data.yardstick_root,
         default_max_year=cfg.validate.db.default_max_year,
         result_sets={
@@ -144,10 +158,12 @@ def validate_db(
                             label="custom-db",
                             name="grype",
                             version=grype_version + f"+import-db={db_info.archive_path}",
+                            profile="acceptance",
                         ),
                         ycfg.Tool(
                             name="grype",
                             version=grype_version,
+                            # profile="acceptance", # TODO: enable after current db is fixed
                         ),
                     ],
                 ),

--- a/manager/src/grype_db_manager/db/validation.py
+++ b/manager/src/grype_db_manager/db/validation.py
@@ -204,7 +204,9 @@ def capture_results(cfg: ycfg.Application, db_uuid: str, result_set: str, root_d
     )
 
     if is_stale or recapture:
-        capture.result_set(result_set=result_set, scan_requests=cfg.result_sets[result_set].scan_requests())
+        capture.result_set(
+            result_set=result_set, scan_requests=cfg.result_sets[result_set].scan_requests(), profiles=cfg.profiles.data,
+        )
     else:
         logging.info(f"skipping grype capture for result-set={result_set} (already exists)")
 

--- a/pkg/process/v4/writer.go
+++ b/pkg/process/v4/writer.go
@@ -79,14 +79,13 @@ func (w writer) Write(entries ...data.Entry) error {
 // but the checksum must be computed after the database is compacted and closed.
 func (w writer) metadataAndClose() (*db.Metadata, error) {
 	storeID, err := w.store.GetID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
+	}
 	w.store.Close()
 	hashStr, err := file.ContentDigest(afero.NewOsFs(), w.dbPath, sha256.New())
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash database file (%s): %w", w.dbPath, err)
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
 	}
 
 	metadata := db.Metadata{

--- a/pkg/process/v4/writer.go
+++ b/pkg/process/v4/writer.go
@@ -73,13 +73,18 @@ func (w writer) Write(entries ...data.Entry) error {
 	return nil
 }
 
-func (w writer) metadata() (*db.Metadata, error) {
+// metadataAndClose closes the database and returns its metadata.
+// The reason this is a compound action is that getting the built time and
+// schema version from the database is an operation on the open database,
+// but the checksum must be computed after the database is compacted and closed.
+func (w writer) metadataAndClose() (*db.Metadata, error) {
+	storeID, err := w.store.GetID()
+	w.store.Close()
 	hashStr, err := file.ContentDigest(afero.NewOsFs(), w.dbPath, sha256.New())
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash database file (%s): %w", w.dbPath, err)
 	}
 
-	storeID, err := w.store.GetID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
 	}
@@ -93,11 +98,10 @@ func (w writer) metadata() (*db.Metadata, error) {
 }
 
 func (w writer) Close() error {
-	metadata, err := w.metadata()
+	metadata, err := w.metadataAndClose()
 	if err != nil {
 		return err
 	}
-	w.store.Close()
 
 	metadataPath := path.Join(filepath.Dir(w.dbPath), db.MetadataFileName)
 	if err = metadata.Write(metadataPath); err != nil {

--- a/pkg/process/v5/writer.go
+++ b/pkg/process/v5/writer.go
@@ -97,14 +97,13 @@ func (w writer) Write(entries ...data.Entry) error {
 // but the checksum must be computed after the database is compacted and closed.
 func (w writer) metadataAndClose() (*db.Metadata, error) {
 	storeID, err := w.store.GetID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
+	}
 	w.store.Close()
 	hashStr, err := file.ContentDigest(afero.NewOsFs(), w.dbPath, sha256.New())
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash database file (%s): %w", w.dbPath, err)
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
 	}
 
 	metadata := db.Metadata{


### PR DESCRIPTION
Otherwise, either the query for the ID will close because the database is closed already, or the checksum will be wrong because closing the database compacts it, which changes its checksum.

See anchore/grype#2076