### PR TITLE
fix: use new platform logic even for only one platform

### DIFF
--- a/pkg/process/v5/transformers/nvd/test-fixtures/CVE-2023-45283-platform-cpe-first.json
+++ b/pkg/process/v5/transformers/nvd/test-fixtures/CVE-2023-45283-platform-cpe-first.json
@@ -1,0 +1,148 @@
+{
+  "cve": {
+    "id": "CVE-2023-45283",
+    "sourceIdentifier": "security@golang.org",
+    "published": "2023-11-09T17:15:08.757",
+    "lastModified": "2023-12-14T10:15:07.947",
+    "vulnStatus": "Modified",
+    "cveTags": [],
+    "descriptions": [
+      {
+        "lang": "en",
+        "value": "The filepath package does not recognize paths with a \\??\\ prefix as special. On Windows, a path beginning with \\??\\ is a Root Local Device path equivalent to a path beginning with \\\\?\\. Paths with a \\??\\ prefix may be used to access arbitrary locations on the system. For example, the path \\??\\c:\\x is equivalent to the more common path c:\\x. Before fix, Clean could convert a rooted path such as \\a\\..\\??\\b into the root local device path \\??\\b. Clean will now convert this to .\\??\\b. Similarly, Join(\\, ??, b) could convert a seemingly innocent sequence of path elements into the root local device path \\??\\b. Join will now convert this to \\.\\??\\b. In addition, with fix, IsAbs now correctly reports paths beginning with \\??\\ as absolute, and VolumeName correctly reports the \\??\\ prefix as a volume name. UPDATE: Go 1.20.11 and Go 1.21.4 inadvertently changed the definition of the volume name in Windows paths starting with \\?, resulting in filepath.Clean(\\?\\c:) returning \\?\\c: rather than \\?\\c:\\ (among other effects). The previous behavior has been restored."
+      },
+      {
+        "lang": "es",
+        "value": "El paquete filepath no reconoce las rutas con el prefijo \\??\\ como especiales. En Windows, una ruta que comienza con \\??\\ es una ruta de dispositivo local raíz equivalente a una ruta que comienza con \\\\?\\. Se pueden utilizar rutas con un prefijo \\??\\ para acceder a ubicaciones arbitrarias en el sistema. Por ejemplo, la ruta \\??\\c:\\x es equivalente a la ruta más común c:\\x. Antes de la solución, Clean podía convertir una ruta raíz como \\a\\..\\??\\b en la ruta raíz del dispositivo local \\??\\b. Clean ahora convertirá esto a .\\??\\b. De manera similar, Join(\\, ??, b) podría convertir una secuencia aparentemente inocente de elementos de ruta en la ruta del dispositivo local raíz \\??\\b. Unirse ahora convertirá esto a \\.\\??\\b. Además, con la solución, IsAbs ahora informa correctamente las rutas que comienzan con \\??\\ como absolutas, y VolumeName informa correctamente el prefijo \\??\\ como nombre de volumen."
+      }
+    ],
+    "metrics": {
+      "cvssMetricV31": [
+        {
+          "source": "nvd@nist.gov",
+          "type": "Primary",
+          "cvssData": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH"
+          },
+          "exploitabilityScore": 3.9,
+          "impactScore": 3.6
+        }
+      ]
+    },
+    "weaknesses": [
+      {
+        "source": "nvd@nist.gov",
+        "type": "Primary",
+        "description": [
+          {
+            "lang": "en",
+            "value": "CWE-22"
+          }
+        ]
+      }
+    ],
+    "configurations": [
+      {
+        "operator": "AND",
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": false,
+                "criteria": "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+                "matchCriteriaId": "A2572D17-1DE6-457B-99CC-64AFD54487EA"
+              }
+            ]
+          },
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "1.20.11",
+                "matchCriteriaId": "C1E7C289-7484-4AA8-A96B-07D2E2933258"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "1.21.0-0",
+                "versionEndExcluding": "1.21.4",
+                "matchCriteriaId": "4E3FC16C-41B2-4900-901F-48BDA3DC9ED2"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "references": [
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2023/12/05/2",
+        "source": "security@golang.org"
+      },
+      {
+        "url": "https://go.dev/cl/540277",
+        "source": "security@golang.org",
+        "tags": [
+          "Issue Tracking",
+          "Vendor Advisory"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/541175",
+        "source": "security@golang.org"
+      },
+      {
+        "url": "https://go.dev/issue/63713",
+        "source": "security@golang.org",
+        "tags": [
+          "Issue Tracking",
+          "Vendor Advisory"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/64028",
+        "source": "security@golang.org"
+      },
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4tU8LZfBFkY",
+        "source": "security@golang.org",
+        "tags": [
+          "Issue Tracking",
+          "Mailing List",
+          "Vendor Advisory"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/g/golang-dev/c/6ypN5EjibjM/m/KmLVYH_uAgAJ",
+        "source": "security@golang.org"
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2023-2185",
+        "source": "security@golang.org",
+        "tags": [
+          "Issue Tracking",
+          "Vendor Advisory"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20231214-0008/",
+        "source": "security@golang.org"
+      }
+    ]
+  }
+}

--- a/pkg/process/v5/transformers/nvd/test-fixtures/CVE-2023-45283-platform-cpe-last.json
+++ b/pkg/process/v5/transformers/nvd/test-fixtures/CVE-2023-45283-platform-cpe-last.json
@@ -1,0 +1,147 @@
+{
+  "cve": {
+    "id": "CVE-2023-45283",
+    "sourceIdentifier": "security@golang.org",
+    "published": "2023-11-09T17:15:08.757",
+    "lastModified": "2023-12-14T10:15:07.947",
+    "vulnStatus": "Modified",
+    "descriptions": [
+      {
+        "lang": "en",
+        "value": "The filepath package does not recognize paths with a \\??\\ prefix as special. On Windows, a path beginning with \\??\\ is a Root Local Device path equivalent to a path beginning with \\\\?\\. Paths with a \\??\\ prefix may be used to access arbitrary locations on the system. For example, the path \\??\\c:\\x is equivalent to the more common path c:\\x. Before fix, Clean could convert a rooted path such as \\a\\..\\??\\b into the root local device path \\??\\b. Clean will now convert this to .\\??\\b. Similarly, Join(\\, ??, b) could convert a seemingly innocent sequence of path elements into the root local device path \\??\\b. Join will now convert this to \\.\\??\\b. In addition, with fix, IsAbs now correctly reports paths beginning with \\??\\ as absolute, and VolumeName correctly reports the \\??\\ prefix as a volume name. UPDATE: Go 1.20.11 and Go 1.21.4 inadvertently changed the definition of the volume name in Windows paths starting with \\?, resulting in filepath.Clean(\\?\\c:) returning \\?\\c: rather than \\?\\c:\\ (among other effects). The previous behavior has been restored."
+      },
+      {
+        "lang": "es",
+        "value": "El paquete filepath no reconoce las rutas con el prefijo \\??\\ como especiales. En Windows, una ruta que comienza con \\??\\ es una ruta de dispositivo local raíz equivalente a una ruta que comienza con \\\\?\\. Se pueden utilizar rutas con un prefijo \\??\\ para acceder a ubicaciones arbitrarias en el sistema. Por ejemplo, la ruta \\??\\c:\\x es equivalente a la ruta más común c:\\x. Antes de la solución, Clean podía convertir una ruta raíz como \\a\\..\\??\\b en la ruta raíz del dispositivo local \\??\\b. Clean ahora convertirá esto a .\\??\\b. De manera similar, Join(\\, ??, b) podría convertir una secuencia aparentemente inocente de elementos de ruta en la ruta del dispositivo local raíz \\??\\b. Unirse ahora convertirá esto a \\.\\??\\b. Además, con la solución, IsAbs ahora informa correctamente las rutas que comienzan con \\??\\ como absolutas, y VolumeName informa correctamente el prefijo \\??\\ como nombre de volumen."
+      }
+    ],
+    "metrics": {
+      "cvssMetricV31": [
+        {
+          "source": "nvd@nist.gov",
+          "type": "Primary",
+          "cvssData": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH"
+          },
+          "exploitabilityScore": 3.9,
+          "impactScore": 3.6
+        }
+      ]
+    },
+    "weaknesses": [
+      {
+        "source": "nvd@nist.gov",
+        "type": "Primary",
+        "description": [
+          {
+            "lang": "en",
+            "value": "CWE-22"
+          }
+        ]
+      }
+    ],
+    "configurations": [
+      {
+        "operator": "AND",
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "1.20.11",
+                "matchCriteriaId": "C1E7C289-7484-4AA8-A96B-07D2E2933258"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "1.21.0-0",
+                "versionEndExcluding": "1.21.4",
+                "matchCriteriaId": "4E3FC16C-41B2-4900-901F-48BDA3DC9ED2"
+              }
+            ]
+          },
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": false,
+                "criteria": "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+                "matchCriteriaId": "A2572D17-1DE6-457B-99CC-64AFD54487EA"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "references": [
+      {
+        "url": "http://www.openwall.com/lists/oss-security/2023/12/05/2",
+        "source": "security@golang.org"
+      },
+      {
+        "url": "https://go.dev/cl/540277",
+        "source": "security@golang.org",
+        "tags": [
+          "Issue Tracking",
+          "Vendor Advisory"
+        ]
+      },
+      {
+        "url": "https://go.dev/cl/541175",
+        "source": "security@golang.org"
+      },
+      {
+        "url": "https://go.dev/issue/63713",
+        "source": "security@golang.org",
+        "tags": [
+          "Issue Tracking",
+          "Vendor Advisory"
+        ]
+      },
+      {
+        "url": "https://go.dev/issue/64028",
+        "source": "security@golang.org"
+      },
+      {
+        "url": "https://groups.google.com/g/golang-announce/c/4tU8LZfBFkY",
+        "source": "security@golang.org",
+        "tags": [
+          "Issue Tracking",
+          "Mailing List",
+          "Vendor Advisory"
+        ]
+      },
+      {
+        "url": "https://groups.google.com/g/golang-dev/c/6ypN5EjibjM/m/KmLVYH_uAgAJ",
+        "source": "security@golang.org"
+      },
+      {
+        "url": "https://pkg.go.dev/vuln/GO-2023-2185",
+        "source": "security@golang.org",
+        "tags": [
+          "Issue Tracking",
+          "Vendor Advisory"
+        ]
+      },
+      {
+        "url": "https://security.netapp.com/advisory/ntap-20231214-0008/",
+        "source": "security@golang.org"
+      }
+    ]
+  }
+}

--- a/pkg/process/v5/transformers/nvd/transform_test.go
+++ b/pkg/process/v5/transformers/nvd/transform_test.go
@@ -587,6 +587,112 @@ func TestParseAllNVDVulnerabilityEntries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "Platform CPE first in CPE config list",
+			numEntries: 1,
+			fixture:    "test-fixtures/CVE-2023-45283-platform-cpe-first.json",
+			vulns: []grypeDB.Vulnerability{
+				{
+					ID:          "CVE-2023-45283",
+					PackageName: "go",
+					Namespace:   "nvd:cpe",
+					PackageQualifiers: []qualifier.Qualifier{platformcpe.Qualifier{
+						Kind: "platform-cpe",
+						CPE:  "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+					}},
+					VersionConstraint:      "< 1.20.11 || >= 1.21.0-0, < 1.21.4",
+					VersionFormat:          "unknown",
+					CPEs:                   []string{"cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*"},
+					RelatedVulnerabilities: nil,
+					Fix: grypeDB.Fix{
+						State: "unknown",
+					},
+					Advisories: nil,
+				},
+			},
+			metadata: grypeDB.VulnerabilityMetadata{
+				ID:           "CVE-2023-45283",
+				Namespace:    "nvd:cpe",
+				DataSource:   "https://nvd.nist.gov/vuln/detail/CVE-2023-45283",
+				RecordSource: "nvdv2:nvdv2:cves",
+				Severity:     "High",
+				URLs: []string{
+					"http://www.openwall.com/lists/oss-security/2023/12/05/2",
+					"https://go.dev/cl/540277",
+					"https://go.dev/cl/541175",
+					"https://go.dev/issue/63713",
+					"https://go.dev/issue/64028",
+					"https://groups.google.com/g/golang-announce/c/4tU8LZfBFkY",
+					"https://groups.google.com/g/golang-dev/c/6ypN5EjibjM/m/KmLVYH_uAgAJ",
+					"https://pkg.go.dev/vuln/GO-2023-2185",
+					"https://security.netapp.com/advisory/ntap-20231214-0008/",
+				},
+				Description: "The filepath package does not recognize paths with a \\??\\ prefix as special. On Windows, a path beginning with \\??\\ is a Root Local Device path equivalent to a path beginning with \\\\?\\. Paths with a \\??\\ prefix may be used to access arbitrary locations on the system. For example, the path \\??\\c:\\x is equivalent to the more common path c:\\x. Before fix, Clean could convert a rooted path such as \\a\\..\\??\\b into the root local device path \\??\\b. Clean will now convert this to .\\??\\b. Similarly, Join(\\, ??, b) could convert a seemingly innocent sequence of path elements into the root local device path \\??\\b. Join will now convert this to \\.\\??\\b. In addition, with fix, IsAbs now correctly reports paths beginning with \\??\\ as absolute, and VolumeName correctly reports the \\??\\ prefix as a volume name. UPDATE: Go 1.20.11 and Go 1.21.4 inadvertently changed the definition of the volume name in Windows paths starting with \\?, resulting in filepath.Clean(\\?\\c:) returning \\?\\c: rather than \\?\\c:\\ (among other effects). The previous behavior has been restored.",
+				Cvss: []grypeDB.Cvss{
+					{
+						VendorMetadata: nil,
+						Metrics:        grypeDB.NewCvssMetrics(7.5, 3.9, 3.6),
+						Vector:         "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+						Version:        "3.1",
+						Source:         "nvd@nist.gov",
+						Type:           "Primary",
+					},
+				},
+			},
+		},
+		{
+			name:       "Platform CPE last in CPE config list",
+			numEntries: 1,
+			fixture:    "test-fixtures/CVE-2023-45283-platform-cpe-last.json",
+			vulns: []grypeDB.Vulnerability{
+				{
+					ID:          "CVE-2023-45283",
+					PackageName: "go",
+					Namespace:   "nvd:cpe",
+					PackageQualifiers: []qualifier.Qualifier{platformcpe.Qualifier{
+						Kind: "platform-cpe",
+						CPE:  "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+					}},
+					VersionConstraint:      "< 1.20.11 || >= 1.21.0-0, < 1.21.4",
+					VersionFormat:          "unknown",
+					CPEs:                   []string{"cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*"},
+					RelatedVulnerabilities: nil,
+					Fix: grypeDB.Fix{
+						State: "unknown",
+					},
+					Advisories: nil,
+				},
+			},
+			metadata: grypeDB.VulnerabilityMetadata{
+				ID:           "CVE-2023-45283",
+				Namespace:    "nvd:cpe",
+				DataSource:   "https://nvd.nist.gov/vuln/detail/CVE-2023-45283",
+				RecordSource: "nvdv2:nvdv2:cves",
+				Severity:     "High",
+				URLs: []string{
+					"http://www.openwall.com/lists/oss-security/2023/12/05/2",
+					"https://go.dev/cl/540277",
+					"https://go.dev/cl/541175",
+					"https://go.dev/issue/63713",
+					"https://go.dev/issue/64028",
+					"https://groups.google.com/g/golang-announce/c/4tU8LZfBFkY",
+					"https://groups.google.com/g/golang-dev/c/6ypN5EjibjM/m/KmLVYH_uAgAJ",
+					"https://pkg.go.dev/vuln/GO-2023-2185",
+					"https://security.netapp.com/advisory/ntap-20231214-0008/",
+				},
+				Description: "The filepath package does not recognize paths with a \\??\\ prefix as special. On Windows, a path beginning with \\??\\ is a Root Local Device path equivalent to a path beginning with \\\\?\\. Paths with a \\??\\ prefix may be used to access arbitrary locations on the system. For example, the path \\??\\c:\\x is equivalent to the more common path c:\\x. Before fix, Clean could convert a rooted path such as \\a\\..\\??\\b into the root local device path \\??\\b. Clean will now convert this to .\\??\\b. Similarly, Join(\\, ??, b) could convert a seemingly innocent sequence of path elements into the root local device path \\??\\b. Join will now convert this to \\.\\??\\b. In addition, with fix, IsAbs now correctly reports paths beginning with \\??\\ as absolute, and VolumeName correctly reports the \\??\\ prefix as a volume name. UPDATE: Go 1.20.11 and Go 1.21.4 inadvertently changed the definition of the volume name in Windows paths starting with \\?, resulting in filepath.Clean(\\?\\c:) returning \\?\\c: rather than \\?\\c:\\ (among other effects). The previous behavior has been restored.",
+				Cvss: []grypeDB.Cvss{
+					{
+						VendorMetadata: nil,
+						Metrics:        grypeDB.NewCvssMetrics(7.5, 3.9, 3.6),
+						Vector:         "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+						Version:        "3.1",
+						Source:         "nvd@nist.gov",
+						Type:           "Primary",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/process/v5/transformers/nvd/unique_pkg.go
+++ b/pkg/process/v5/transformers/nvd/unique_pkg.go
@@ -97,7 +97,7 @@ func platformPackageCandidates(set uniquePkgTracker, c nvd.Configuration) bool {
 			platformsNode = n
 		}
 	}
-	if platformsNode.Operator != nvd.Or || len(platformsNode.CpeMatch) < 2 {
+	if platformsNode.Operator != nvd.Or {
 		return false
 	}
 	if applicationNode.Operator != nvd.Or {

--- a/pkg/process/v5/transformers/nvd/unique_pkg.go
+++ b/pkg/process/v5/transformers/nvd/unique_pkg.go
@@ -151,20 +151,6 @@ func noCPEsVulnerable(node nvd.Node) bool {
 	return true
 }
 
-func determinePlatformCPEAndNodes(c nvd.Configuration) (string, []nvd.Node) {
-	var platformCPE string
-	nodes := c.Nodes
-
-	if len(nodes) == 2 && c.Operator != nil && *c.Operator == nvd.And {
-		if len(nodes[1].CpeMatch) == 1 && !nodes[1].CpeMatch[0].Vulnerable {
-			platformCPE = nodes[1].CpeMatch[0].Criteria
-			nodes = []nvd.Node{nodes[0]}
-		}
-	}
-
-	return platformCPE, nodes
-}
-
 func _findUniquePkgs(set uniquePkgTracker, c nvd.Configuration) {
 	if len(c.Nodes) == 0 {
 		return
@@ -174,10 +160,9 @@ func _findUniquePkgs(set uniquePkgTracker, c nvd.Configuration) {
 		return
 	}
 
-	platformCPE, nodes := determinePlatformCPEAndNodes(c)
-	for _, node := range nodes {
+	for _, node := range c.Nodes {
 		for _, match := range node.CpeMatch {
-			candidate, err := newPkgCandidate(match, platformCPE)
+			candidate, err := newPkgCandidate(match, "")
 			if err != nil {
 				// Do not halt all execution because of being unable to create
 				// a PkgCandidate. This can happen when a CPE is invalid which

--- a/pkg/process/v5/transformers/nvd/unique_pkg_test.go
+++ b/pkg/process/v5/transformers/nvd/unique_pkg_test.go
@@ -310,6 +310,94 @@ func TestFindUniquePkgs(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name:     "single platform CPE as first element",
+			operator: opRef(nvd.And),
+			nodes: []nvd.Node{
+				{
+					Negate:   boolRef(false),
+					Operator: nvd.Or,
+					CpeMatch: []nvd.CpeMatch{
+						{
+							Criteria:        "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+							MatchCriteriaID: "902B8056-9E37-443B-8905-8AA93E2447FB",
+							Vulnerable:      false,
+						},
+					},
+				},
+				{
+					Negate:   boolRef(false),
+					Operator: nvd.Or,
+					CpeMatch: []nvd.CpeMatch{
+						{
+							Criteria:              "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+							VersionEndExcluding:   strRef("1.22.2"),
+							VersionStartIncluding: strRef("1.22"),
+							MatchCriteriaID:       "5EBE5E1C-C881-4A76-9E36-4FB7C48427E6",
+							Vulnerable:            true,
+						},
+						{
+							Criteria:            "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+							VersionEndExcluding: strRef("1.21.8"),
+							MatchCriteriaID:     "5EBE5E1C-C881-4A76-9E36-4FB7C48427E6",
+							Vulnerable:          true,
+						},
+					},
+				},
+			},
+			expected: newUniquePkgTrackerFromSlice([]pkgCandidate{
+				{
+					Product:        "go",
+					Vendor:         "golang",
+					TargetSoftware: ANY,
+					PlatformCPE:    "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+				},
+			}),
+		},
+		{
+			name:     "single platform CPE as last element",
+			operator: opRef(nvd.And),
+			nodes: []nvd.Node{
+				{
+					Negate:   boolRef(false),
+					Operator: nvd.Or,
+					CpeMatch: []nvd.CpeMatch{
+						{
+							Criteria:              "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+							VersionEndExcluding:   strRef("1.22.2"),
+							VersionStartIncluding: strRef("1.22"),
+							MatchCriteriaID:       "5EBE5E1C-C881-4A76-9E36-4FB7C48427E6",
+							Vulnerable:            true,
+						},
+						{
+							Criteria:            "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+							VersionEndExcluding: strRef("1.21.8"),
+							MatchCriteriaID:     "5EBE5E1C-C881-4A76-9E36-4FB7C48427E6",
+							Vulnerable:          true,
+						},
+					},
+				},
+				{
+					Negate:   boolRef(false),
+					Operator: nvd.Or,
+					CpeMatch: []nvd.CpeMatch{
+						{
+							Criteria:        "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+							MatchCriteriaID: "902B8056-9E37-443B-8905-8AA93E2447FB",
+							Vulnerable:      false,
+						},
+					},
+				},
+			},
+			expected: newUniquePkgTrackerFromSlice([]pkgCandidate{
+				{
+					Product:        "go",
+					Vendor:         "golang",
+					TargetSoftware: ANY,
+					PlatformCPE:    "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+				},
+			}),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Previously, this function would fall back to legacy behavior if it was looking at a configuration with a single platform CPE. However, the legacy behavior is incorrect for some orderings of the platform and application CPEs, so stop falling back.

## TODO:

- [x] verify that this removal has no other side effects
- [x] if the old fallback is now unreachable, remove it entirely