### PR TITLE
fix: allow empty matches on old schema versions

### DIFF
--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -48,6 +48,9 @@ gates:
       max_new_false_negatives: 10
       max_year: 2022 # important - Azure Linux 3 doesn't have enough CVEs going back to 2021
       candidate_tool_label: 'custom-db'
+    # Old versions of grype don't recognize Azure Linux 3, and so will make an
+    # empty result set
+    allow_empty_results_for_schemas: [1,2,3,4]
 
     images:
       - docker.io/anchore/test_images:azurelinux3-63671fe@sha256:2d761ba36575ddd4e07d446f4f2a05448298c20e5bdcd3dedfbbc00f9865240d

--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -40,7 +40,9 @@ gates:
       - docker.io/debian:7@sha256:81e88820a7759038ffa61cff59dfcc12d3772c3a2e75b7cfe963c952da2ad264
       - registry.access.redhat.com/ubi8@sha256:68fecea0d255ee253acbf0c860eaebb7017ef5ef007c25bee9eeffd29ce85b29
       - docker.io/ubuntu:20.04@sha256:9d42d0e3e57bc067d10a75ee33bdd1a5298e95e5fc3c5d1fce98b455cb879249
-
+    # Old versions of grype may find no matches for some newer images
+    # Do not fail quality gate over this
+    allow_empty_results_for_schemas: [1,2]
 
   - gate:
       max_f1_regression: 0.15

--- a/manager/src/grype_db_manager/cli/config.py
+++ b/manager/src/grype_db_manager/cli/config.py
@@ -51,6 +51,7 @@ class ValidateDB:
     images: list[str] = field(default_factory=list)
     grype: Grype = field(default_factory=Grype)
     gate: Validation = field(default_factory=Validation)
+    allow_empty_results_for_schemas: list[int] = field(default_factory=list)
 
     def __post_init__(self):
         # flatten elements in images (in case yaml anchors are used)

--- a/manager/src/grype_db_manager/cli/db.py
+++ b/manager/src/grype_db_manager/cli/db.py
@@ -98,12 +98,6 @@ def show_db(cfg: config.Application, db_uuid: str) -> None:
     is_flag=True,
     help="do not ensure the minimum expected namespaces are present",
 )
-@click.option(
-    "--allow-empty-matches",
-    "allow_empty_matches",
-    is_flag=True,
-    help="set 'fail_on_empty_matches' to false when invoking yardstick validate",
-)
 @click.argument("db-uuid")
 @click.pass_obj
 @click.pass_context
@@ -115,7 +109,6 @@ def validate_db(
     verbosity: int,
     recapture: bool,
     skip_namespace_check: bool,
-    allow_empty_matches: bool,
 ) -> None:
     logging.info(f"validating DB {db_uuid}")
 
@@ -145,7 +138,7 @@ def validate_db(
             logging.info(f"no images found for gate {idx}")
             continue
 
-        if allow_empty_matches:
+        if db_info.schema_version in rs.allow_empty_results_for_schemas:
             rs.gate.fail_on_empty_match_set = False
 
         logging.info(f"writing config for result set result_set_{idx}")

--- a/manager/tests/unit/cli/fixtures/config/full.yaml
+++ b/manager/tests/unit/cli/fixtures/config/full.yaml
@@ -42,5 +42,6 @@ validate:
         max_unlabeled_percent: 50
         max_new_false_negatives: 10
         max_year: 2021
+      allow_empty_results_for_schemas: [1,2,3]
       images:
         - docker.io/cloudbees/cloudbees-core-agent:2.289.2.2@sha256:d48f0546b4cf5ef4626136242ce302f94a42751156b7be42f4b1b75a66608880

--- a/manager/tests/unit/cli/test_config.py
+++ b/manager/tests/unit/cli/test_config.py
@@ -108,7 +108,11 @@ schemaMappingFile: mapping.json
 validate:
   defaultMaxYear: 2021
   gates:
-    - gate:
+    - allowEmptyResultsForSchemas:
+        - 1
+        - 2
+        - 3
+      gate:
         allowedNamespaces: []
         candidateToolLabel: candidate
         failOnEmptyMatchSet: true

--- a/test/db/acceptance.sh
+++ b/test/db/acceptance.sh
@@ -26,9 +26,4 @@ fi
 
 title "Validating DB"
 
-ALLOW_EMPTY=""
-if [[ "$SCHEMA_VERSION" == "1" || "$SCHEMA_VERSION" == "2" || "$SCHEMA_VERSION" == "3" || "$SCHEMA_VERSION" == "4" ]]; then
-  ALLOW_EMPTY="--allow-empty-matches"
-fi
-
-grype-db-manager db validate $DB_ID -vvv $ALLOW_EMPTY
+grype-db-manager db validate $DB_ID -vvv


### PR DESCRIPTION
Versions of Grype using a schema before 5 will not recognize vulns in Azure Linux 3, so allow empty matches on the new result set for schemas 1 through 4.

Previously, db validate had an `--allow-empty-matches` flag that was sometimes passed, but because `grype-db-manager` is usually used in a mode where it validates every schema at once, it's simpler to wire up a config field that allows particular gates to have particular schemas that are allowed to be empty.

So this PR has 2 effects:

1. Change the prod config, so that for the new, small result set, when building and validating, allow old versions of grype to report empty matches on the new result set
2. Change the `db validate` CLI to use a configured value that specifies a list of schemas to allow empty matches on for a given set of images, rather than have to pass `--allow-empty-matches` conditionally and in multiple places.