### PR TITLE
Use migrated grype DB distribution package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.5.0
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a
-	github.com/anchore/grype v0.81.1-0.20240926144921-2264f134ddff
+	github.com/anchore/grype v0.81.1-0.20240930133029-8a687c4a5522
 	github.com/anchore/syft v1.13.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/glebarez/sqlite v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.5.0
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a
-	github.com/anchore/grype v0.81.0
+	github.com/anchore/grype v0.81.1-0.20240926144921-2264f134ddff
 	github.com/anchore/syft v1.13.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/glebarez/sqlite v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.81.0 h1:hlnSwQjobIb3oKSLZrgKusoijU2PTi86z5fZBf3XSbM=
-github.com/anchore/grype v0.81.0/go.mod h1:NwocNorrJLiaTyceEVkd5LsoawPKyrJ/V1fb4i/5/IQ=
+github.com/anchore/grype v0.81.1-0.20240926144921-2264f134ddff h1:ctTwF3QN0Dhgw0pNUBZMx/Xmf0+QD9p0od5yr154IrY=
+github.com/anchore/grype v0.81.1-0.20240926144921-2264f134ddff/go.mod h1:NwocNorrJLiaTyceEVkd5LsoawPKyrJ/V1fb4i/5/IQ=
 github.com/anchore/packageurl-go v0.1.1-0.20240507183024-848e011fc24f h1:B/E9ixKNCasntpoch61NDaQyGPDXLEJlL+B9B/PbdbA=
 github.com/anchore/packageurl-go v0.1.1-0.20240507183024-848e011fc24f/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.3 h1:JRPHySy8S6P+Ff3IDiQ29ap1i8/laUQxDk9K1eFh/2U=

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.81.1-0.20240926144921-2264f134ddff h1:ctTwF3QN0Dhgw0pNUBZMx/Xmf0+QD9p0od5yr154IrY=
-github.com/anchore/grype v0.81.1-0.20240926144921-2264f134ddff/go.mod h1:NwocNorrJLiaTyceEVkd5LsoawPKyrJ/V1fb4i/5/IQ=
+github.com/anchore/grype v0.81.1-0.20240930133029-8a687c4a5522 h1:UFgSRb2ar3taA5ZKH7Wz0g+WbPUhXn20bR+1vnapCHo=
+github.com/anchore/grype v0.81.1-0.20240930133029-8a687c4a5522/go.mod h1:NwocNorrJLiaTyceEVkd5LsoawPKyrJ/V1fb4i/5/IQ=
 github.com/anchore/packageurl-go v0.1.1-0.20240507183024-848e011fc24f h1:B/E9ixKNCasntpoch61NDaQyGPDXLEJlL+B9B/PbdbA=
 github.com/anchore/packageurl-go v0.1.1-0.20240507183024-848e011fc24f/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.3 h1:JRPHySy8S6P+Ff3IDiQ29ap1i8/laUQxDk9K1eFh/2U=

--- a/pkg/process/package.go
+++ b/pkg/process/package.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/internal/tarutil"
-	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/db/legacy/distribution"
 )
 
 func secondsSinceEpoch() int64 {
@@ -23,7 +23,7 @@ func Package(dbDir, publishBaseURL, overrideArchiveExtension string) error {
 	log.WithFields("from", dbDir, "url", publishBaseURL, "extension-override", overrideArchiveExtension).Info("packaging database")
 
 	fs := afero.NewOsFs()
-	metadata, err := db.NewMetadataFromDir(fs, dbDir)
+	metadata, err := distribution.NewMetadataFromDir(fs, dbDir)
 	if err != nil {
 		return err
 	}
@@ -84,13 +84,13 @@ func Package(dbDir, publishBaseURL, overrideArchiveExtension string) error {
 
 	log.WithFields("path", tarPath).Info("created database archive")
 
-	entry, err := db.NewListingEntryFromArchive(fs, *metadata, tarPath, u)
+	entry, err := distribution.NewListingEntryFromArchive(fs, *metadata, tarPath, u)
 	if err != nil {
 		return fmt.Errorf("unable to create listing entry from archive: %w", err)
 	}
 
-	listing := db.NewListing(entry)
-	listingPath := path.Join(dbDir, db.ListingFileName)
+	listing := distribution.NewListing(entry)
+	listingPath := path.Join(dbDir, distribution.ListingFileName)
 	if err = listing.Write(listingPath); err != nil {
 		return err
 	}

--- a/pkg/process/v1/writer.go
+++ b/pkg/process/v1/writer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/anchore/grype-db/internal/file"
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
-	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/db/legacy/distribution"
 	grypeDB "github.com/anchore/grype/grype/db/v1"
 	grypeDBStore "github.com/anchore/grype/grype/db/v1/store"
 )
@@ -65,7 +65,7 @@ func (w writer) Write(entries ...data.Entry) error {
 	return nil
 }
 
-func (w writer) metadata() (*db.Metadata, error) {
+func (w writer) metadata() (*distribution.Metadata, error) {
 	hashStr, err := file.ContentDigest(afero.NewOsFs(), w.dbPath, sha256.New())
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash database file (%s): %w", w.dbPath, err)
@@ -76,7 +76,7 @@ func (w writer) metadata() (*db.Metadata, error) {
 		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
 	}
 
-	metadata := db.Metadata{
+	metadata := distribution.Metadata{
 		Built:    storeID.BuildTimestamp,
 		Version:  storeID.SchemaVersion,
 		Checksum: "sha256:" + hashStr,
@@ -91,7 +91,7 @@ func (w writer) Close() error {
 		return err
 	}
 
-	metadataPath := path.Join(filepath.Dir(w.dbPath), db.MetadataFileName)
+	metadataPath := path.Join(filepath.Dir(w.dbPath), distribution.MetadataFileName)
 	if err = metadata.Write(metadataPath); err != nil {
 		return err
 	}

--- a/pkg/process/v2/writer.go
+++ b/pkg/process/v2/writer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/anchore/grype-db/internal/file"
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
-	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/db/legacy/distribution"
 	grypeDB "github.com/anchore/grype/grype/db/v2"
 	grypeDBStore "github.com/anchore/grype/grype/db/v2/store"
 )
@@ -65,7 +65,7 @@ func (w writer) Write(entries ...data.Entry) error {
 	return nil
 }
 
-func (w writer) metadata() (*db.Metadata, error) {
+func (w writer) metadata() (*distribution.Metadata, error) {
 	hashStr, err := file.ContentDigest(afero.NewOsFs(), w.dbPath, sha256.New())
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash database file (%s): %w", w.dbPath, err)
@@ -76,7 +76,7 @@ func (w writer) metadata() (*db.Metadata, error) {
 		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
 	}
 
-	metadata := db.Metadata{
+	metadata := distribution.Metadata{
 		Built:    storeID.BuildTimestamp,
 		Version:  storeID.SchemaVersion,
 		Checksum: "sha256:" + hashStr,
@@ -91,7 +91,7 @@ func (w writer) Close() error {
 		return err
 	}
 
-	metadataPath := path.Join(filepath.Dir(w.dbPath), db.MetadataFileName)
+	metadataPath := path.Join(filepath.Dir(w.dbPath), distribution.MetadataFileName)
 	if err = metadata.Write(metadataPath); err != nil {
 		return err
 	}

--- a/pkg/process/v3/writer.go
+++ b/pkg/process/v3/writer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/anchore/grype-db/internal/file"
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
-	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/db/legacy/distribution"
 	grypeDB "github.com/anchore/grype/grype/db/v3"
 	grypeDBStore "github.com/anchore/grype/grype/db/v3/store"
 )
@@ -66,7 +66,7 @@ func (w writer) Write(entries ...data.Entry) error {
 	return nil
 }
 
-func (w writer) metadata() (*db.Metadata, error) {
+func (w writer) metadata() (*distribution.Metadata, error) {
 	hashStr, err := file.ContentDigest(afero.NewOsFs(), w.dbPath, sha256.New())
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash database file (%s): %w", w.dbPath, err)
@@ -77,7 +77,7 @@ func (w writer) metadata() (*db.Metadata, error) {
 		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
 	}
 
-	metadata := db.Metadata{
+	metadata := distribution.Metadata{
 		Built:    storeID.BuildTimestamp,
 		Version:  storeID.SchemaVersion,
 		Checksum: "sha256:" + hashStr,
@@ -92,7 +92,7 @@ func (w writer) Close() error {
 		return err
 	}
 
-	metadataPath := path.Join(filepath.Dir(w.dbPath), db.MetadataFileName)
+	metadataPath := path.Join(filepath.Dir(w.dbPath), distribution.MetadataFileName)
 	if err = metadata.Write(metadataPath); err != nil {
 		return err
 	}

--- a/pkg/process/v4/writer.go
+++ b/pkg/process/v4/writer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/anchore/grype-db/internal/file"
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
-	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/db/legacy/distribution"
 	grypeDB "github.com/anchore/grype/grype/db/v4"
 	grypeDBStore "github.com/anchore/grype/grype/db/v4/store"
 )
@@ -77,7 +77,7 @@ func (w writer) Write(entries ...data.Entry) error {
 // The reason this is a compound action is that getting the built time and
 // schema version from the database is an operation on the open database,
 // but the checksum must be computed after the database is compacted and closed.
-func (w writer) metadataAndClose() (*db.Metadata, error) {
+func (w writer) metadataAndClose() (*distribution.Metadata, error) {
 	storeID, err := w.store.GetID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
@@ -88,7 +88,7 @@ func (w writer) metadataAndClose() (*db.Metadata, error) {
 		return nil, fmt.Errorf("failed to hash database file (%s): %w", w.dbPath, err)
 	}
 
-	metadata := db.Metadata{
+	metadata := distribution.Metadata{
 		Built:    storeID.BuildTimestamp,
 		Version:  storeID.SchemaVersion,
 		Checksum: "sha256:" + hashStr,
@@ -102,7 +102,7 @@ func (w writer) Close() error {
 		return err
 	}
 
-	metadataPath := path.Join(filepath.Dir(w.dbPath), db.MetadataFileName)
+	metadataPath := path.Join(filepath.Dir(w.dbPath), distribution.MetadataFileName)
 	if err = metadata.Write(metadataPath); err != nil {
 		return err
 	}

--- a/pkg/process/v5/writer.go
+++ b/pkg/process/v5/writer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
 	"github.com/anchore/grype-db/pkg/provider"
-	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/db/legacy/distribution"
 	grypeDB "github.com/anchore/grype/grype/db/v5"
 	grypeDBStore "github.com/anchore/grype/grype/db/v5/store"
 )
@@ -95,7 +95,7 @@ func (w writer) Write(entries ...data.Entry) error {
 // The reason this is a compound action is that getting the built time and
 // schema version from the database is an operation on the open database,
 // but the checksum must be computed after the database is compacted and closed.
-func (w writer) metadataAndClose() (*db.Metadata, error) {
+func (w writer) metadataAndClose() (*distribution.Metadata, error) {
 	storeID, err := w.store.GetID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch store ID: %w", err)
@@ -106,7 +106,7 @@ func (w writer) metadataAndClose() (*db.Metadata, error) {
 		return nil, fmt.Errorf("failed to hash database file (%s): %w", w.dbPath, err)
 	}
 
-	metadata := db.Metadata{
+	metadata := distribution.Metadata{
 		Built:    storeID.BuildTimestamp,
 		Version:  storeID.SchemaVersion,
 		Checksum: "sha256:" + hashStr,
@@ -138,7 +138,7 @@ func (w writer) Close() error {
 		return err
 	}
 
-	metadataPath := path.Join(filepath.Dir(w.dbPath), db.MetadataFileName)
+	metadataPath := path.Join(filepath.Dir(w.dbPath), distribution.MetadataFileName)
 	if err = metadata.Write(metadataPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
In preparation for v6, all distribution concerns are now a per-schema concern. In this case all v1-5 distribution concerns have been migrated to their own package.