### PR TITLE
Add config for CPE part filtering

### DIFF
--- a/cmd/grype-db/cli/options/build.go
+++ b/cmd/grype-db/cli/options/build.go
@@ -17,14 +17,15 @@ type Build struct {
 	SchemaVersion  int  `yaml:"schema-version" json:"schema-version" mapstructure:"schema-version"`
 
 	// unbound options
-	// (none)
+	IncludeCPEParts []string `yaml:"include-cpe-parts" json:"include-cpe-parts" mapstructure:"include-cpe-parts"`
 }
 
 func DefaultBuild() Build {
 	return Build{
-		DBLocation:     DefaultDBLocation(),
-		SkipValidation: false,
-		SchemaVersion:  process.DefaultSchemaVersion,
+		DBLocation:      DefaultDBLocation(),
+		SkipValidation:  false,
+		SchemaVersion:   process.DefaultSchemaVersion,
+		IncludeCPEParts: []string{"a"},
 	}
 }
 
@@ -54,7 +55,7 @@ func (o *Build) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
 	}
 
 	// set default values for non-bound struct items
-	// (none)
+	v.SetDefault("build.include-cpe-parts", o.IncludeCPEParts)
 
 	return o.DBLocation.BindFlags(flags, v)
 }

--- a/pkg/process/v5/processors.go
+++ b/pkg/process/v5/processors.go
@@ -1,6 +1,8 @@
 package v5
 
 import (
+	"github.com/scylladb/go-set/strset"
+
 	"github.com/anchore/grype-db/pkg/data"
 	"github.com/anchore/grype-db/pkg/process/processors"
 	"github.com/anchore/grype-db/pkg/process/v5/transformers/github"
@@ -10,11 +12,32 @@ import (
 	"github.com/anchore/grype-db/pkg/process/v5/transformers/os"
 )
 
-func Processors() []data.Processor {
+type Config struct {
+	NVD nvd.Config
+}
+
+type Option func(cfg *Config)
+
+func WithCPEParts(included []string) Option {
+	return func(cfg *Config) {
+		cfg.NVD.CPEParts = strset.New(included...)
+	}
+}
+
+func NewConfig(options ...Option) Config {
+	var cfg Config
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	return cfg
+}
+
+func Processors(cfg Config) []data.Processor {
 	return []data.Processor{
 		processors.NewGitHubProcessor(github.Transform),
 		processors.NewMSRCProcessor(msrc.Transform),
-		processors.NewNVDProcessor(nvd.Transform),
+		processors.NewNVDProcessor(nvd.Transformer(cfg.NVD)),
 		processors.NewOSProcessor(os.Transform),
 		processors.NewMatchExclusionProcessor(matchexclusions.Transform),
 	}

--- a/pkg/process/v5/transformers/nvd/transform.go
+++ b/pkg/process/v5/transformers/nvd/transform.go
@@ -21,7 +21,26 @@ import (
 	"github.com/anchore/syft/syft/cpe"
 )
 
-func Transform(vulnerability unmarshal.NVDVulnerability) ([]data.Entry, error) {
+type Config struct {
+	CPEParts *strset.Set
+}
+
+func defaultConfig() Config {
+	return Config{
+		CPEParts: strset.New("a"),
+	}
+}
+
+func Transformer(cfg Config) data.NVDTransformer {
+	if cfg == (Config{}) {
+		cfg = defaultConfig()
+	}
+	return func(vulnerability unmarshal.NVDVulnerability) ([]data.Entry, error) {
+		return transform(cfg, vulnerability)
+	}
+}
+
+func transform(cfg Config, vulnerability unmarshal.NVDVulnerability) ([]data.Entry, error) {
 	// TODO: stop capturing record source in the vulnerability metadata record (now that feed groups are not real)
 	recordSource := "nvdv2:nvdv2:cves"
 
@@ -32,7 +51,7 @@ func Transform(vulnerability unmarshal.NVDVulnerability) ([]data.Entry, error) {
 
 	entryNamespace := grypeNamespace.String()
 
-	uniquePkgs := findUniquePkgs(vulnerability.Configurations...)
+	uniquePkgs := findUniquePkgs(cfg, vulnerability.Configurations...)
 
 	// extract all links
 	var links []string

--- a/pkg/process/v5/transformers/nvd/transform_test.go
+++ b/pkg/process/v5/transformers/nvd/transform_test.go
@@ -32,6 +32,7 @@ func TestParseAllNVDVulnerabilityEntries(t *testing.T) {
 
 	tests := []struct {
 		name       string
+		config     Config
 		numEntries int
 		fixture    string
 		vulns      []grypeDB.Vulnerability
@@ -708,6 +709,9 @@ func TestParseAllNVDVulnerabilityEntries(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.config == (Config{}) {
+				test.config = defaultConfig()
+			}
 			f, err := os.Open(test.fixture)
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -719,7 +723,7 @@ func TestParseAllNVDVulnerabilityEntries(t *testing.T) {
 
 			var vulns []grypeDB.Vulnerability
 			for _, entry := range entries {
-				dataEntries, err := Transform(entry.Cve)
+				dataEntries, err := transform(test.config, entry.Cve)
 				require.NoError(t, err)
 
 				for _, entry := range dataEntries {


### PR DESCRIPTION
A new `build.include-cpe-parts` configuration has been added that will only allow including CPES from NVD entries with a specific part value. The CLI validates that only `a`, `h`, and `o` may be provided from the user. The default is to include only `a`.

```yaml
# .grype-db.yaml
build:
    include-cpe-parts: ["a", "o"]
```


