### PR TITLE
Remove support for v1 & v2 schemas

### DIFF
--- a/manager/src/grype_db_manager/data/schema-info.json
+++ b/manager/src/grype_db_manager/data/schema-info.json
@@ -3,12 +3,12 @@
     {
       "schema": "1",
       "grype-version": "v0.7.0",
-      "supported": true
+      "supported": false
     },
     {
       "schema": "2",
       "grype-version": "v0.12.1",
-      "supported": true
+      "supported": false
     },
     {
       "schema": "3",

--- a/manager/tests/unit/db/test_schema.py
+++ b/manager/tests/unit/db/test_schema.py
@@ -14,4 +14,4 @@ def test_grype_version():
 
 
 def test_supported_schema_versions():
-    assert schema.supported_schema_versions() == [1, 2, 3, 4, 5]
+    assert schema.supported_schema_versions() == [3, 4, 5]


### PR DESCRIPTION
Per https://github.com/anchore/grype/issues/2075 we will no longer be building DBs for v1 & v2 schemas.

Closes https://github.com/anchore/grype/issues/2075