### PR TITLE
Ignore NVD data age when crafting DB timestamp

### DIFF
--- a/cmd/grype-db/cli/commands/build.go
+++ b/cmd/grype-db/cli/commands/build.go
@@ -151,9 +151,15 @@ func providerStates(skipValidation bool, providers []provider.Provider) ([]provi
 func earliestTimestamp(states []provider.State) time.Time {
 	earliest := states[0].Timestamp
 	for _, s := range states {
+		// the NVD api is constantly down, so we don't want to consider it for the earliest timestamp
+		if s.Provider == "nvd" {
+			log.WithFields("provider", s.Provider).Trace("not considering data age for provider")
+			continue
+		}
 		if s.Timestamp.Before(earliest) {
 			earliest = s.Timestamp
 		}
 	}
+	log.WithFields("timestamp", earliest).Debug("earliest data timestamp")
 	return earliest
 }


### PR DESCRIPTION
Today the age of the data going into the DB is what the "DB timestamp" is, however, the NVD API has been returning 503s for an extended period of time. This will start affecting the default configuration of grype very shortly (failing scans automatically due to DB ager), thus, we need to ignore the NVD provider date until they have restored their service.

Related to https://github.com/anchore/grype/issues/2282