### PR TITLE
Ignore NVD data age

### DIFF
--- a/cmd/grype-db/cli/commands/build_test.go
+++ b/cmd/grype-db/cli/commands/build_test.go
@@ -5,14 +5,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/anchore/grype-db/pkg/provider"
 )
 
 func Test_earliestTimestamp(t *testing.T) {
 	tests := []struct {
-		name   string
-		states []provider.State
-		want   time.Time
+		name    string
+		states  []provider.State
+		want    time.Time
+		wantErr require.ErrorAssertionFunc
 	}{
 		{
 			name: "happy path",
@@ -29,12 +32,91 @@ func Test_earliestTimestamp(t *testing.T) {
 			},
 			want: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
+		{
+			name:    "empty states",
+			states:  []provider.State{},
+			want:    time.Time{},
+			wantErr: requireErrorContains("cannot find earliest timestamp: no states provided"),
+		},
+		{
+			name: "single state",
+			states: []provider.State{
+				{
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			want: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "all states have provider nvd",
+			states: []provider.State{
+				{
+					Provider:  "nvd",
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Provider:  "nvd",
+					Timestamp: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			want:    time.Time{},
+			wantErr: requireErrorContains("unable to determine earliest timestamp"),
+		},
+		{
+			name: "mix of nvd and non-nvd providers",
+			states: []provider.State{
+				{
+					Provider:  "nvd",
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Provider:  "other",
+					Timestamp: time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Provider:  "other",
+					Timestamp: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			want: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "timestamps are the same",
+			states: []provider.State{
+				{
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			want: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := earliestTimestamp(tt.states); !reflect.DeepEqual(got, tt.want) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+			got, err := earliestTimestamp(tt.states)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("earliestTimestamp() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func requireErrorContains(text string) require.ErrorAssertionFunc {
+	return func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+		require.Error(t, err, msgAndArgs...)
+		require.Contains(t, err.Error(), text, msgAndArgs...)
 	}
 }


### PR DESCRIPTION
This is an additional fix on top of #440 -- the original PR did not consider if NVD was the first provider on the list.

Example run:
```
[0002] DEBUG state validated for all providers
[0002] TRACE not considering data age for provider provider=nvd
[0002] DEBUG earliest data timestamp timestamp=2024-11-25 01:31:56.419535 +0000 +0000
[0002]  INFO building database build-directory=./build providers=[nvd alpine amazon chainguard debian github mariner oracle rhel sles ubuntu wolfi] schema=5

```