### PR TITLE
Add more retry attempts for NVD provider

### DIFF
--- a/.vunnel.yaml
+++ b/.vunnel.yaml
@@ -13,3 +13,10 @@ providers:
     # apply community-provided overrides to the NVD data
     # sourced from the https://github.com/anchore/nvd-data-overrides repo
     overrides_enabled: true
+
+    # we're getting a lot of 503s and intermittent failures from the NVD API, so we're going to retry a few times
+    request_timeout: 250
+    runtime:
+      on_error:
+        retry_count: 10
+        retry_delay: 60


### PR DESCRIPTION
We're seeing that the NVD provider has ~250000 updates to CVEs waiting for us (we usually see no more then a few dozen to few hundred), but the API is intermittent and returning 503s a lot of the time. The best guess is that there's been a large data dump upstream and their incremental API is being over leveraged while everyone works through the backlog. We've seen some success locally with more retry attempts -- this PR adds such a configuration.