### PR TITLE
Add request retry count for NVD

### DIFF
--- a/.vunnel.yaml
+++ b/.vunnel.yaml
@@ -15,7 +15,8 @@ providers:
     overrides_enabled: true
 
     # we're getting a lot of 503s and intermittent failures from the NVD API, so we're going to retry a few times
-    request_timeout: 250
+    request_timeout: 125
+    request_retry_count: 15
     runtime:
       on_error:
         retry_count: 10


### PR DESCRIPTION
Incorporates https://github.com/anchore/vunnel/pull/738 and adds more aggressive retries while also changing the request timeout to something less aggressive.