### PR TITLE
fix: use timestamp from only provider if only one provider

### DIFF
--- a/cmd/grype-db/cli/commands/build.go
+++ b/cmd/grype-db/cli/commands/build.go
@@ -157,6 +157,13 @@ func earliestTimestamp(states []provider.State) (time.Time, error) {
 	if len(states) == 0 {
 		return time.Time{}, fmt.Errorf("cannot find earliest timestamp: no states provided")
 	}
+
+	// special case when there is exactly 1 state, return its timestamp even
+	// if it is nvd, because otherwise quality gates that pull only nvd deterministically fail.
+	if len(states) == 1 {
+		return states[0].Timestamp, nil
+	}
+
 	var earliest time.Time
 	for _, s := range states {
 		// the NVD api is constantly down, so we don't want to consider it for the earliest timestamp

--- a/cmd/grype-db/cli/commands/build_test.go
+++ b/cmd/grype-db/cli/commands/build_test.go
@@ -48,6 +48,16 @@ func Test_earliestTimestamp(t *testing.T) {
 			want: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
+			name: "single state, but it's nvd",
+			states: []provider.State{
+				{
+					Provider:  "nvd",
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			want: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
 			name: "all states have provider nvd",
 			states: []provider.State{
 				{


### PR DESCRIPTION
Because building the NVD provider is unreliable right now, normally grype-db won't consider the NVD time as the earliest timestamp. However, if NVD is the only provider, report it anyway, because otherwise single-provider grype-db builds always fail for NVD.

This is meant to fix errors like this one: https://github.com/anchore/vunnel/actions/runs/12112985815/job/33767270739#step:4:2298