### PR TITLE
Add release ID to OS models

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.5.3
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a
-	github.com/anchore/grype v0.86.2-0.20241218195423-d94e68a680dc
+	github.com/anchore/grype v0.86.2-0.20241223182831-3baa3d2ca99a
 	github.com/anchore/syft v1.18.2-0.20241216153735-397eb9c10acd
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/dave/jennifer v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.86.2-0.20241218195423-d94e68a680dc h1:DmRYOnqIuu81SZzac60zscLGf/NXQe6FFnNBPoXV71c=
-github.com/anchore/grype v0.86.2-0.20241218195423-d94e68a680dc/go.mod h1:rqbEt5hrFdlJ8nrk8VFv0A77XD4gzhkWk8LU9iU77AA=
+github.com/anchore/grype v0.86.2-0.20241223182831-3baa3d2ca99a h1:7vWYvOsRaJmFUOk4YKrRdaFGi/SIo32IY8+tcUZiyQk=
+github.com/anchore/grype v0.86.2-0.20241223182831-3baa3d2ca99a/go.mod h1:rqbEt5hrFdlJ8nrk8VFv0A77XD4gzhkWk8LU9iU77AA=
 github.com/anchore/packageurl-go v0.1.1-0.20241018175412-5c22e6360c4f h1:dAQPIrQ3a5PBqZeZ+B9NGZsGmodk4NO9OjDIsQmQyQM=
 github.com/anchore/packageurl-go v0.1.1-0.20241018175412-5c22e6360c4f/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
 github.com/anchore/stereoscope v0.0.11 h1:d+dePyWyQzoQehnWOnx/aISW5HW1zLAQKzvaFIpydsU=


### PR DESCRIPTION
Populates the OperatingSystem model for grype schema v6 with the original release ID (provided by vunnel providers).