### PR TITLE
Pin vunnel providers

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -9,7 +9,19 @@ provider:
   # for every new provider that is added.
   #
   # Any providers that should be excluded from processing should be added to the 'provider.vunnel.excludeProviders' list.
-  configs: []
+  configs:
+    - name: nvd
+    - name: alpine
+    - name: amazon
+    - name: chainguard
+    - name: debian
+    - name: github
+    - name: mariner
+    - name: oracle
+    - name: rhel
+    - name: sles
+    - name: ubuntu
+    - name: wolfi
 
   vunnel:
     executor: docker

--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -26,7 +26,7 @@ provider:
   vunnel:
     executor: docker
     docker-tag: latest
-    generate-configs: true
+    generate-configs: false
     env:
       GITHUB_TOKEN: $GITHUB_TOKEN
       NVD_API_KEY: $NVD_API_KEY

--- a/config/grype-db/publish-nightly.yaml
+++ b/config/grype-db/publish-nightly.yaml
@@ -9,7 +9,19 @@ provider:
   # for every new provider that is added.
   #
   # Any providers that should be excluded from processing should be added to the 'provider.vunnel.excludeProviders' list.
-  configs: []
+  configs:
+    - name: nvd
+    - name: alpine
+    - name: amazon
+    - name: chainguard
+    - name: debian
+    - name: github
+    - name: mariner
+    - name: oracle
+    - name: rhel
+    - name: sles
+    - name: ubuntu
+    - name: wolfi
 
   vunnel:
     executor: docker

--- a/config/grype-db/publish-nightly.yaml
+++ b/config/grype-db/publish-nightly.yaml
@@ -26,7 +26,7 @@ provider:
   vunnel:
     executor: docker
     docker-tag: latest
-    generate-configs: true
+    generate-configs: false
     env:
       GITHUB_TOKEN: $GITHUB_TOKEN
       NVD_API_KEY: $NVD_API_KEY


### PR DESCRIPTION
Today we always run all vunnel providers, however, we may be adding more in the future that should not automatically be run by grype-db. For this reason we're pinning the specific providers that should be in the DB.