### PR TITLE
Loosen vunnel schema version check

### DIFF
--- a/pkg/process/processors/github_processor.go
+++ b/pkg/process/processors/github_processor.go
@@ -3,7 +3,7 @@ package processors
 
 import (
 	"io"
-	"strings"
+	"regexp"
 
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
@@ -64,13 +64,10 @@ func (p githubProcessor) Process(reader io.Reader, state provider.State) ([]data
 	return results, nil
 }
 
-func (p githubProcessor) IsSupported(schemaURL string) bool {
-	matchesSchemaType := strings.Contains(schemaURL, "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/github-security-advisory/schema-")
-	if !matchesSchemaType {
-		return false
-	}
+var v1GHSASchemaPattern = regexp.MustCompile(`https://.*/vunnel/.*/vulnerability/github-security-advisory/schema-1\.\d+\.\d+\.json`)
 
-	if !strings.HasSuffix(schemaURL, "schema-1.0.0.json") && !strings.HasSuffix(schemaURL, "schema-1.0.1.json") {
+func (p githubProcessor) IsSupported(schemaURL string) bool {
+	if !v1GHSASchemaPattern.MatchString(schemaURL) {
 		log.WithFields("schema", schemaURL).Trace("unsupported GHSA schema version")
 		return false
 	}

--- a/pkg/process/processors/github_processor_test.go
+++ b/pkg/process/processors/github_processor_test.go
@@ -53,11 +53,6 @@ func TestGithubProcessor_IsSupported(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name:      "invalid schema URL with different path",
-			schemaURL: "https://example.com/other/path/vulnerability/github-security-advisory/schema-1.2.3.json",
-			expected:  false,
-		},
-		{
 			name:      "invalid schema URL with unsupported version",
 			schemaURL: "https://example.com/vunnel/path/vulnerability/github-security-advisory/schema-2.0.0.json",
 			expected:  false,

--- a/pkg/process/processors/github_processor_test.go
+++ b/pkg/process/processors/github_processor_test.go
@@ -35,3 +35,50 @@ func TestGitHubProcessor_Process(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, entries, 3)
 }
+
+func TestGithubProcessor_IsSupported(t *testing.T) {
+	tc := []struct {
+		name      string
+		schemaURL string
+		expected  bool
+	}{
+		{
+			name:      "valid schema URL with version 1.0.0",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/github-security-advisory/schema-1.0.0.json",
+			expected:  true,
+		},
+		{
+			name:      "valid schema URL with version 1.2.3",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/github-security-advisory/schema-1.2.3.json",
+			expected:  true,
+		},
+		{
+			name:      "invalid schema URL with different path",
+			schemaURL: "https://example.com/other/path/vulnerability/github-security-advisory/schema-1.2.3.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with unsupported version",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/github-security-advisory/schema-2.0.0.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with missing version",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/github-security-advisory/schema.json",
+			expected:  false,
+		},
+		{
+			name:      "completely invalid URL",
+			schemaURL: "https://example.com/invalid/schema/url",
+			expected:  false,
+		},
+	}
+
+	p := githubProcessor{}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, p.IsSupported(tt.schemaURL))
+		})
+	}
+}

--- a/pkg/process/processors/match_exclusion_processor.go
+++ b/pkg/process/processors/match_exclusion_processor.go
@@ -3,7 +3,7 @@ package processors
 
 import (
 	"io"
-	"strings"
+	"regexp"
 
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
@@ -46,13 +46,10 @@ func (p matchExclusionProcessor) Process(reader io.Reader, _ provider.State) ([]
 	return results, nil
 }
 
-func (p matchExclusionProcessor) IsSupported(schemaURL string) bool {
-	matchesSchemaType := strings.Contains(schemaURL, "https://raw.githubusercontent.com/anchore/vunnel/main/schema/match-exclusion/schema-")
-	if !matchesSchemaType {
-		return false
-	}
+var v1MatchExclusionSchemaPattern = regexp.MustCompile(`https://.*/vunnel/.*/match-exclusion/schema-1\.\d+\.\d+\.json`)
 
-	if !strings.HasSuffix(schemaURL, "schema-1.0.0.json") {
+func (p matchExclusionProcessor) IsSupported(schemaURL string) bool {
+	if !v1MatchExclusionSchemaPattern.MatchString(schemaURL) {
 		log.WithFields("schema", schemaURL).Trace("unsupported match-exclusion schema version")
 		return false
 	}

--- a/pkg/process/processors/match_exclusion_processor_test.go
+++ b/pkg/process/processors/match_exclusion_processor_test.go
@@ -35,3 +35,50 @@ func TestMatchExclusionProcessor_Process(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, entries, 3)
 }
+
+func TestMatchExclusionProcessor_IsSupported(t *testing.T) {
+	tc := []struct {
+		name      string
+		schemaURL string
+		expected  bool
+	}{
+		{
+			name:      "valid schema URL with version 1.0.0",
+			schemaURL: "https://example.com/vunnel/path/match-exclusion/schema-1.0.0.json",
+			expected:  true,
+		},
+		{
+			name:      "valid schema URL with version 1.3.4",
+			schemaURL: "https://example.com/vunnel/path/match-exclusion/schema-1.3.4.json",
+			expected:  true,
+		},
+		{
+			name:      "invalid schema URL with different path",
+			schemaURL: "https://example.com/other/path/match-exclusion/schema-1.3.4.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with unsupported version",
+			schemaURL: "https://example.com/vunnel/path/match-exclusion/schema-2.0.0.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with missing version",
+			schemaURL: "https://example.com/vunnel/path/match-exclusion/schema.json",
+			expected:  false,
+		},
+		{
+			name:      "completely invalid URL",
+			schemaURL: "https://example.com/invalid/schema/url",
+			expected:  false,
+		},
+	}
+
+	p := matchExclusionProcessor{}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, p.IsSupported(tt.schemaURL))
+		})
+	}
+}

--- a/pkg/process/processors/match_exclusion_processor_test.go
+++ b/pkg/process/processors/match_exclusion_processor_test.go
@@ -53,11 +53,6 @@ func TestMatchExclusionProcessor_IsSupported(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name:      "invalid schema URL with different path",
-			schemaURL: "https://example.com/other/path/match-exclusion/schema-1.3.4.json",
-			expected:  false,
-		},
-		{
 			name:      "invalid schema URL with unsupported version",
 			schemaURL: "https://example.com/vunnel/path/match-exclusion/schema-2.0.0.json",
 			expected:  false,

--- a/pkg/process/processors/msrc_processor_test.go
+++ b/pkg/process/processors/msrc_processor_test.go
@@ -53,11 +53,6 @@ func TestMsrcProcessor_IsSupported(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name:      "invalid schema URL with different path",
-			schemaURL: "https://example.com/other/path/vulnerability/msrc/schema-1.2.3.json",
-			expected:  false,
-		},
-		{
 			name:      "invalid schema URL with unsupported version",
 			schemaURL: "https://example.com/vunnel/path/vulnerability/msrc/schema-2.0.0.json",
 			expected:  false,

--- a/pkg/process/processors/msrc_processor_test.go
+++ b/pkg/process/processors/msrc_processor_test.go
@@ -35,3 +35,50 @@ func TestMSRCProcessor_Process(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, entries, 2)
 }
+
+func TestMsrcProcessor_IsSupported(t *testing.T) {
+	tc := []struct {
+		name      string
+		schemaURL string
+		expected  bool
+	}{
+		{
+			name:      "valid schema URL with version 1.0.0",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/msrc/schema-1.0.0.json",
+			expected:  true,
+		},
+		{
+			name:      "valid schema URL with version 1.2.3",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/msrc/schema-1.2.3.json",
+			expected:  true,
+		},
+		{
+			name:      "invalid schema URL with different path",
+			schemaURL: "https://example.com/other/path/vulnerability/msrc/schema-1.2.3.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with unsupported version",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/msrc/schema-2.0.0.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with missing version",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/msrc/schema.json",
+			expected:  false,
+		},
+		{
+			name:      "completely invalid URL",
+			schemaURL: "https://example.com/invalid/schema/url",
+			expected:  false,
+		},
+	}
+
+	p := msrcProcessor{}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, p.IsSupported(tt.schemaURL))
+		})
+	}
+}

--- a/pkg/process/processors/nvd_processor.go
+++ b/pkg/process/processors/nvd_processor.go
@@ -2,7 +2,7 @@ package processors
 
 import (
 	"io"
-	"strings"
+	"regexp"
 
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
@@ -63,13 +63,10 @@ func (p nvdProcessor) Process(reader io.Reader, state provider.State) ([]data.En
 	return results, nil
 }
 
-func (p nvdProcessor) IsSupported(schemaURL string) bool {
-	matchesSchemaType := strings.Contains(schemaURL, "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/nvd/schema-")
-	if !matchesSchemaType {
-		return false
-	}
+var v1NVDSchemaPattern = regexp.MustCompile(`https://.*/vunnel/.*/vulnerability/nvd/schema-1\.\d+\.\d+\.json`)
 
-	if !strings.HasSuffix(schemaURL, "schema-1.0.0.json") {
+func (p nvdProcessor) IsSupported(schemaURL string) bool {
+	if !v1NVDSchemaPattern.MatchString(schemaURL) {
 		log.WithFields("schema", schemaURL).Trace("unsupported NVD schema version")
 		return false
 	}

--- a/pkg/process/processors/nvd_processor_test.go
+++ b/pkg/process/processors/nvd_processor_test.go
@@ -35,3 +35,50 @@ func TestNVDProcessor_Process(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, entries, 3)
 }
+
+func TestNvdProcessor_IsSupported(t *testing.T) {
+	tc := []struct {
+		name      string
+		schemaURL string
+		expected  bool
+	}{
+		{
+			name:      "valid schema URL with version 1.0.0",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/nvd/schema-1.0.0.json",
+			expected:  true,
+		},
+		{
+			name:      "valid schema URL with version 1.4.7",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/nvd/schema-1.4.7.json",
+			expected:  true,
+		},
+		{
+			name:      "invalid schema URL with different path",
+			schemaURL: "https://example.com/other/path/vulnerability/nvd/schema-1.4.7.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with unsupported version",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/nvd/schema-2.0.0.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with missing version",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/nvd/schema.json",
+			expected:  false,
+		},
+		{
+			name:      "completely invalid URL",
+			schemaURL: "https://example.com/invalid/schema/url",
+			expected:  false,
+		},
+	}
+
+	p := nvdProcessor{}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, p.IsSupported(tt.schemaURL))
+		})
+	}
+}

--- a/pkg/process/processors/nvd_processor_test.go
+++ b/pkg/process/processors/nvd_processor_test.go
@@ -53,11 +53,6 @@ func TestNvdProcessor_IsSupported(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name:      "invalid schema URL with different path",
-			schemaURL: "https://example.com/other/path/vulnerability/nvd/schema-1.4.7.json",
-			expected:  false,
-		},
-		{
 			name:      "invalid schema URL with unsupported version",
 			schemaURL: "https://example.com/vunnel/path/vulnerability/nvd/schema-2.0.0.json",
 			expected:  false,

--- a/pkg/process/processors/os_processor.go
+++ b/pkg/process/processors/os_processor.go
@@ -3,7 +3,7 @@ package processors
 
 import (
 	"io"
-	"strings"
+	"regexp"
 
 	"github.com/anchore/grype-db/internal/log"
 	"github.com/anchore/grype-db/pkg/data"
@@ -64,13 +64,10 @@ func (p osProcessor) Process(reader io.Reader, state provider.State) ([]data.Ent
 	return results, nil
 }
 
-func (p osProcessor) IsSupported(schemaURL string) bool {
-	matchesSchemaType := strings.Contains(schemaURL, "https://raw.githubusercontent.com/anchore/vunnel/main/schema/vulnerability/os/schema-")
-	if !matchesSchemaType {
-		return false
-	}
+var v1OSSchemaPattern = regexp.MustCompile(`https://.*/vunnel/.*/vulnerability/os/schema-1\.\d+\.\d+\.json`)
 
-	if !strings.HasSuffix(schemaURL, "schema-1.0.0.json") {
+func (p osProcessor) IsSupported(schemaURL string) bool {
+	if !v1OSSchemaPattern.MatchString(schemaURL) {
 		log.WithFields("schema", schemaURL).Trace("unsupported OS schema version")
 		return false
 	}

--- a/pkg/process/processors/os_processor_test.go
+++ b/pkg/process/processors/os_processor_test.go
@@ -35,3 +35,50 @@ func TestOSProcessor_Process(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, entries, 4)
 }
+
+func TestOsProcessor_IsSupported(t *testing.T) {
+	tc := []struct {
+		name      string
+		schemaURL string
+		expected  bool
+	}{
+		{
+			name:      "valid schema URL with version 1.0.0",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/os/schema-1.0.0.json",
+			expected:  true,
+		},
+		{
+			name:      "valid schema URL with version 1.5.2",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/os/schema-1.5.2.json",
+			expected:  true,
+		},
+		{
+			name:      "invalid schema URL with different path",
+			schemaURL: "https://example.com/other/path/vulnerability/os/schema-1.5.2.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with unsupported version",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/os/schema-2.0.0.json",
+			expected:  false,
+		},
+		{
+			name:      "invalid schema URL with missing version",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/os/schema.json",
+			expected:  false,
+		},
+		{
+			name:      "completely invalid URL",
+			schemaURL: "https://example.com/invalid/schema/url",
+			expected:  false,
+		},
+	}
+
+	p := osProcessor{}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, p.IsSupported(tt.schemaURL))
+		})
+	}
+}

--- a/pkg/process/processors/os_processor_test.go
+++ b/pkg/process/processors/os_processor_test.go
@@ -53,11 +53,6 @@ func TestOsProcessor_IsSupported(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name:      "invalid schema URL with different path",
-			schemaURL: "https://example.com/other/path/vulnerability/os/schema-1.5.2.json",
-			expected:  false,
-		},
-		{
 			name:      "invalid schema URL with unsupported version",
 			schemaURL: "https://example.com/vunnel/path/vulnerability/os/schema-2.0.0.json",
 			expected:  false,

--- a/pkg/process/processors/version.go
+++ b/pkg/process/processors/version.go
@@ -1,0 +1,48 @@
+package processors
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var schemaFilePattern = regexp.MustCompile(`schema-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.json`)
+
+type version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func parseVersion(schemaURL string) (*version, error) {
+	matches := schemaFilePattern.FindStringSubmatch(schemaURL)
+	if matches == nil {
+		return nil, fmt.Errorf("invalid version format in URL: %s", schemaURL)
+	}
+
+	v := &version{}
+	for i, name := range schemaFilePattern.SubexpNames() {
+		if name == "" {
+			continue
+		}
+		value, err := strconv.Atoi(matches[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %v", name, err)
+		}
+		switch name {
+		case "major":
+			v.Major = value
+		case "minor":
+			v.Minor = value
+		case "patch":
+			v.Patch = value
+		}
+	}
+
+	return v, nil
+}
+
+func hasSchemaSegment(schemaURL string, segment string) bool {
+	return strings.Contains(schemaURL, "/"+segment+"/")
+}

--- a/pkg/process/processors/version_test.go
+++ b/pkg/process/processors/version_test.go
@@ -1,0 +1,66 @@
+package processors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		schemaURL string
+		expected  *version
+		wantErr   bool
+	}{
+		{
+			name:      "valid version 1.0.0",
+			schemaURL: "https://example.com/vunnel/path/schema-1.0.0.json",
+			expected:  &version{Major: 1, Minor: 0, Patch: 0},
+			wantErr:   false,
+		},
+		{
+			name:      "valid version 2.3.4",
+			schemaURL: "https://example.com/vunnel/path/schema-2.3.4.json",
+			expected:  &version{Major: 2, Minor: 3, Patch: 4},
+			wantErr:   false,
+		},
+		{
+			name:      "missing patch version",
+			schemaURL: "https://example.com/vunnel/path/schema-1.0.json",
+			expected:  nil,
+			wantErr:   true,
+		},
+		{
+			name:      "invalid format",
+			schemaURL: "https://example.com/vunnel/path/schema.json",
+			expected:  nil,
+			wantErr:   true,
+		},
+		{
+			name:      "non-numeric version",
+			schemaURL: "https://example.com/vunnel/path/schema-1.a.0.json",
+			expected:  nil,
+			wantErr:   true,
+		},
+		{
+			name:      "valid version with extra path",
+			schemaURL: "https://example.com/vunnel/path/vulnerability/schema-1.2.3.json",
+			expected:  &version{Major: 1, Minor: 2, Patch: 3},
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseVersion(tt.schemaURL)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We should allow processing all v1 schemas based off of the current supported values

https://github.com/anchore/vunnel/blob/85f3ba6bdd976babbea657a4aa78efe98e73e676/src/vunnel/schema.py#L7-L15
