### PR TITLE
Fix listing.json validations threshold

### DIFF
--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -2,7 +2,7 @@
 
 listing:
   image: "alpine:3.9.2"
-  minimum-packages: 10
+  minimum-packages: 5
   minimum-vulnerabilities: 90
 
 expected-providers:


### PR DESCRIPTION
When switching to alpine it was missed that there would be fewer than 10 packages (there should be 7). This drops the threshold to be a little lower than that to tolerate changes to vulnerability data.