### PR TITLE
Skip release gate for unexpected acceptance tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Read supported schema versions
         id: read-schema-versions
         run: |
-          content=`cat manager/src/grype_db_manager/data/schema-info.json | jq -c '[.available[] | select(.supported == true) | .schema]'`
+          content=`cat manager/src/grype_db_manager/data/schema-info.json | jq -c '[.available[] | select(.supported == true) | select(.validate != false) | .schema]'`
           echo "schema-versions=$content" >> $GITHUB_OUTPUT
 
   quality-gate-acceptance-test:


### PR DESCRIPTION
While working on a new schema version it is possible to configure a new version that is published but quality gates are skipped -- including acceptance tests. This removes looking for acceptance test completions for schema versions that are supported but explicitly not running validations for.