### PR TITLE
Add severity entries to missing vulnerability records (v6 only)

### DIFF
--- a/pkg/process/v6/writer.go
+++ b/pkg/process/v6/writer.go
@@ -2,6 +2,7 @@ package v6
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/anchore/grype-db/internal/log"
@@ -18,6 +19,7 @@ type writer struct {
 	store         grypeDB.ReadWriter
 	providerCache map[string]grypeDB.Provider
 	states        provider.States
+	severityCache map[string]grypeDB.Severity
 }
 
 type ProviderMetadata struct {
@@ -47,6 +49,7 @@ func NewWriter(directory string, states provider.States) (data.Writer, error) {
 		providerCache: make(map[string]grypeDB.Provider),
 		store:         s,
 		states:        states,
+		severityCache: make(map[string]grypeDB.Severity),
 	}, nil
 }
 
@@ -69,8 +72,11 @@ func (w writer) Write(entries ...data.Entry) error {
 	return nil
 }
 
-func (w writer) writeEntry(entry transformers.RelatedEntries) error {
+func (w *writer) writeEntry(entry transformers.RelatedEntries) error {
 	log.WithFields("entry", entry.String()).Trace("writing entry")
+
+	w.normalizeSeverity(&entry.VulnerabilityHandle)
+
 	if err := w.store.AddVulnerabilities(&entry.VulnerabilityHandle); err != nil {
 		return fmt.Errorf("unable to write vulnerability to store: %w", err)
 	}
@@ -94,6 +100,79 @@ func (w writer) writeEntry(entry transformers.RelatedEntries) error {
 	}
 
 	return nil
+}
+
+func (w *writer) normalizeSeverity(handle *grypeDB.VulnerabilityHandle) {
+	if handle == nil {
+		return
+	}
+
+	blob := handle.BlobValue
+	if blob == nil {
+		return
+	}
+
+	id := strings.ToLower(blob.ID)
+	isCVE := strings.HasPrefix(id, "cve-")
+	if strings.ToLower(handle.ProviderID) == "nvd" && isCVE {
+		if len(blob.Severities) > 0 {
+			w.severityCache[id] = blob.Severities[0]
+		}
+		return
+	}
+
+	if !isCVE {
+		return
+	}
+
+	// parse all string severities and remove all unknown values
+	sevs := filterUnknownSeverities(blob.Severities)
+
+	topSevStr := "none"
+	if len(sevs) > 0 {
+		switch v := sevs[0].Value.(type) {
+		case string:
+			topSevStr = v
+		case fmt.Stringer:
+			topSevStr = v.String()
+		default:
+			topSevStr = fmt.Sprintf("%v", sevs[0].Value)
+		}
+	}
+
+	if len(sevs) > 0 {
+		return // already has a severity, don't normalize
+	}
+
+	// add the top NVD severity value
+	nvdSev, ok := w.severityCache[id]
+	if !ok {
+		log.WithFields("id", blob.ID).Trace("unable to find NVD severity")
+		return
+	}
+
+	log.WithFields("id", blob.ID, "provider", handle.Provider, "sev-from", topSevStr, "sev-to", nvdSev).Trace("overriding irrelevant severity with data from NVD record")
+	sevs = append([]grypeDB.Severity{nvdSev}, sevs...)
+	handle.BlobValue.Severities = sevs
+}
+
+func filterUnknownSeverities(sevs []grypeDB.Severity) []grypeDB.Severity {
+	var out []grypeDB.Severity
+	for _, s := range sevs {
+		if isKnownSeverity(s) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func isKnownSeverity(s grypeDB.Severity) bool {
+	switch v := s.Value.(type) {
+	case string:
+		return v != "" && strings.ToLower(v) != "unknown"
+	default:
+		return v != nil
+	}
 }
 
 func (w writer) Close() error {

--- a/pkg/process/v6/writer.go
+++ b/pkg/process/v6/writer.go
@@ -75,7 +75,7 @@ func (w writer) Write(entries ...data.Entry) error {
 func (w *writer) writeEntry(entry transformers.RelatedEntries) error {
 	log.WithFields("entry", entry.String()).Trace("writing entry")
 
-	w.normalizeSeverity(&entry.VulnerabilityHandle)
+	w.fillInMissingSeverity(&entry.VulnerabilityHandle)
 
 	if err := w.store.AddVulnerabilities(&entry.VulnerabilityHandle); err != nil {
 		return fmt.Errorf("unable to write vulnerability to store: %w", err)
@@ -102,7 +102,10 @@ func (w *writer) writeEntry(entry transformers.RelatedEntries) error {
 	return nil
 }
 
-func (w *writer) normalizeSeverity(handle *grypeDB.VulnerabilityHandle) {
+// fillInMissingSeverity will add a severity entry to the vulnerability record if it is missing, empty, or "unknown".
+// The upstream NVD record is used to fill in these missing values. Note that the NVD provider is always guaranteed
+// to be processed first before other providers.
+func (w *writer) fillInMissingSeverity(handle *grypeDB.VulnerabilityHandle) {
 	if handle == nil {
 		return
 	}

--- a/pkg/process/v6/writer_test.go
+++ b/pkg/process/v6/writer_test.go
@@ -1,0 +1,233 @@
+package v6
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	grypeDB "github.com/anchore/grype/grype/db/v6"
+)
+
+func TestNormalizeSeverity(t *testing.T) {
+	tests := []struct {
+		name              string
+		handle            *grypeDB.VulnerabilityHandle
+		severityCache     map[string]grypeDB.Severity
+		expected          []grypeDB.Severity
+		expectCacheUpdate bool
+	}{
+		{
+			name:          "nil handle",
+			handle:        nil,
+			severityCache: map[string]grypeDB.Severity{},
+			expected:      nil,
+		},
+		{
+			name: "nil metadata",
+			handle: &grypeDB.VulnerabilityHandle{
+				BlobValue: nil,
+			},
+			severityCache: map[string]grypeDB.Severity{},
+			expected:      nil,
+		},
+		{
+			name: "non-CVE ID",
+			handle: &grypeDB.VulnerabilityHandle{
+				BlobValue: &grypeDB.VulnerabilityBlob{
+					ID: "GHSA-123",
+					Severities: []grypeDB.Severity{
+						{Value: "high"},
+					},
+				},
+			},
+			severityCache: map[string]grypeDB.Severity{},
+			expected:      []grypeDB.Severity{{Value: "high"}},
+		},
+		{
+			name: "NVD provider with CVE",
+			handle: &grypeDB.VulnerabilityHandle{
+				ProviderID: "nvd",
+				BlobValue: &grypeDB.VulnerabilityBlob{
+					ID: "CVE-2023-1234",
+					Severities: []grypeDB.Severity{
+						{Value: "critical"},
+					},
+				},
+			},
+			severityCache:     map[string]grypeDB.Severity{},
+			expected:          []grypeDB.Severity{{Value: "critical"}},
+			expectCacheUpdate: true,
+		},
+		{
+			name: "CVE with existing severities",
+			handle: &grypeDB.VulnerabilityHandle{
+				ProviderID: "github",
+				BlobValue: &grypeDB.VulnerabilityBlob{
+					ID: "CVE-2023-5678",
+					Severities: []grypeDB.Severity{
+						{Value: "medium"},
+						{Value: "high"},
+					},
+				},
+			},
+			severityCache: map[string]grypeDB.Severity{
+				"cve-2023-5678": {Value: "critical"},
+			},
+			expected: []grypeDB.Severity{
+				{Value: "medium"},
+				{Value: "high"},
+			},
+		},
+		{
+			name: "CVE with no severities, using cache",
+			handle: &grypeDB.VulnerabilityHandle{
+				ProviderID: "github",
+				BlobValue: &grypeDB.VulnerabilityBlob{
+					ID:         "CVE-2023-9012",
+					Severities: []grypeDB.Severity{},
+				},
+			},
+			severityCache: map[string]grypeDB.Severity{
+				"cve-2023-9012": {Value: "high"},
+			},
+			expected: []grypeDB.Severity{{Value: "high"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &writer{
+				severityCache: tt.severityCache,
+			}
+
+			if tt.expectCacheUpdate {
+				// assert expected ids are not in the cache
+				if tt.handle != nil && tt.handle.BlobValue != nil {
+					assert.NotContains(t, tt.severityCache, strings.ToLower(tt.handle.BlobValue.ID))
+				}
+			}
+
+			w.normalizeSeverity(tt.handle)
+
+			if tt.handle == nil || tt.handle.BlobValue == nil {
+				return
+			}
+
+			if tt.expectCacheUpdate {
+				// assert expected ids are not in the cache
+				if tt.handle != nil && tt.handle.BlobValue != nil {
+					id := strings.ToLower(tt.handle.BlobValue.ID)
+					assert.Equal(t, tt.severityCache[id], w.severityCache[id])
+				}
+			}
+
+			assert.Equal(t, tt.expected, tt.handle.BlobValue.Severities)
+		})
+	}
+}
+
+func TestFilterUnknownSeverities(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []grypeDB.Severity
+		expected []grypeDB.Severity
+	}{
+		{
+			name:     "empty input",
+			input:    []grypeDB.Severity{},
+			expected: nil,
+		},
+		{
+			name: "all known severities",
+			input: []grypeDB.Severity{
+				{Value: "critical"},
+				{Value: "high"},
+				{Value: "medium"},
+			},
+			expected: []grypeDB.Severity{
+				{Value: "critical"},
+				{Value: "high"},
+				{Value: "medium"},
+			},
+		},
+		{
+			name: "mix of known and unknown",
+			input: []grypeDB.Severity{
+				{Value: "high"},
+				{Value: "unknown"},
+				{Value: "medium"},
+				{Value: ""},
+			},
+			expected: []grypeDB.Severity{
+				{Value: "high"},
+				{Value: "medium"},
+			},
+		},
+		{
+			name: "non-string values",
+			input: []grypeDB.Severity{
+				{Value: 5},
+				{Value: nil},
+				{Value: "high"},
+			},
+			expected: []grypeDB.Severity{
+				{Value: 5},
+				{Value: "high"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterUnknownSeverities(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsKnownSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity grypeDB.Severity
+		expected bool
+	}{
+		{
+			name:     "empty string",
+			severity: grypeDB.Severity{Value: ""},
+			expected: false,
+		},
+		{
+			name:     "unknown string",
+			severity: grypeDB.Severity{Value: "unknown"},
+			expected: false,
+		},
+		{
+			name:     "case insensitive",
+			severity: grypeDB.Severity{Value: "UNKNOWN"},
+			expected: false,
+		},
+		{
+			name:     "valid string severity",
+			severity: grypeDB.Severity{Value: "high"},
+			expected: true,
+		},
+		{
+			name:     "nil value",
+			severity: grypeDB.Severity{Value: nil},
+			expected: false,
+		},
+		{
+			name:     "numeric value",
+			severity: grypeDB.Severity{Value: 7},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isKnownSeverity(tt.severity)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/process/v6/writer_test.go
+++ b/pkg/process/v6/writer_test.go
@@ -9,7 +9,7 @@ import (
 	grypeDB "github.com/anchore/grype/grype/db/v6"
 )
 
-func TestNormalizeSeverity(t *testing.T) {
+func TestFillInMissingSeverity(t *testing.T) {
 	tests := []struct {
 		name              string
 		handle            *grypeDB.VulnerabilityHandle
@@ -108,7 +108,7 @@ func TestNormalizeSeverity(t *testing.T) {
 				}
 			}
 
-			w.normalizeSeverity(tt.handle)
+			w.fillInMissingSeverity(tt.handle)
 
 			if tt.handle == nil || tt.handle.BlobValue == nil {
 				return


### PR DESCRIPTION
This mimics the v5 behavior of pulling NVD severities for records that have no severity or have an explicitly unknown severity.