### PR TITLE
Merge v5 build and listing operations

### DIFF
--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -29,7 +29,7 @@ jobs:
     # a) booleans come across as string types :(
     # b) if not using workflow_dispatch the default values are empty, which means we want these to effectively evaluate to true (so only check the negative case)
     if: ${{ github.event.inputs.publish-databases != 'false' }}
-    name: "Pull vulnerability data"
+    name: "Discover schemas"
     runs-on: ubuntu-24.04
     outputs:
       schema-versions: ${{ steps.read-schema-versions.outputs.schema-versions }}
@@ -53,7 +53,7 @@ jobs:
     # a) booleans come across as string types :(
     # b) if not using workflow_dispatch the default values are empty, which means we want these to effectively evaluate to true (so only check the negative case)
     if: ${{ github.event.inputs.publish-databases != 'false' }}
-    name: "Generate and publish DBs"
+    name: "Publish"
     needs: discover-schema-versions
     runs-on: ubuntu-22.04-4core-16gb
     strategy:
@@ -103,54 +103,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
         if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
 
-  publish-listing-file:
-    # fun! https://github.com/actions/runner/issues/491#issuecomment-850884422
-    # essentially even if the workflow dispatch job is skipping steps, we still want to run this step.
-    # however, if not running from a workflow dispatch then we want the job ordering to be honored.
-    # also...
-    # note about workflow dispatch inputs and booleans:
-    # a) booleans come across as string types :(
-    # b) if not using workflow_dispatch the default values are empty, which means we want these to effectively evaluate to true (so only check the negative case)
-    if: |
-      always() &&
-      (needs.generate-and-publish-dbs.result == 'success' || needs.generate-and-publish-dbs.result == 'skipped') &&
-      github.event.inputs.publish-listing != 'false'
-
-    name: "Publish listing file"
-    needs: generate-and-publish-dbs
-    runs-on: ubuntu-22.04-4core-16gb
-    steps:
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-        with:
-          submodules: true
-
-      - name: Bootstrap environment
-        uses: ./.github/actions/bootstrap
-
-      - name: Publish listing file
-        run: |
-          uv run \
-            grype-db-manager \
-              -c ./config/grype-db-manager/publish-production-r2.yaml \
-                listing update
-        env:
-            AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_CLOUDFLARE_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_CLOUDFLARE_SECRET_ACCESS_KEY }}
-            GRYPE_DB_MANAGER_DISTRIBUTION_S3_ENDPOINT_URL: ${{ secrets.TOOLBOX_CLOUDFLARE_R2_ENDPOINT }}
-
-      - uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 #v3.16.2
-        with:
-          status: ${{ job.status }}
-          fields: workflow,eventName,job
-          text: Publishing the Grype DB listing file has failed
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
-
   sync-listing-file-to-s3:
     name: "Sync listing file to S3"
     needs:
-      - publish-listing-file
+      - generate-and-publish-dbs
     uses: ./.github/workflows/copy-listing-from-r2.yaml
     secrets: inherit

--- a/.github/workflows/fix-v5-listing.yaml
+++ b/.github/workflows/fix-v5-listing.yaml
@@ -1,0 +1,65 @@
+name: 'Fix v5 listing'
+on:
+  # allow for kicking off DB builds manually
+  workflow_dispatch:
+    inputs:
+      publish-databases:
+        description: "build new databases and upload to S3"
+        type: boolean
+        required: true
+        default: true
+      publish-listing:
+        description: "use S3 state to update and publish listing file"
+        type: boolean
+        required: true
+        default: true
+
+  # run 4 AM (UTC) daily
+  schedule:
+    - cron:  '0 4 * * *'
+
+env:
+  CGO_ENABLED: "0"
+  SLACK_NOTIFICATIONS: true
+  FORCE_COLOR: true
+
+jobs:
+
+  publish-listing-file:
+    name: "Publish listing file"
+    runs-on: ubuntu-22.04-4core-16gb
+    steps:
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          submodules: true
+
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
+
+      - name: Publish listing file
+        run: |
+          uv run \
+            grype-db-manager \
+              -c ./config/grype-db-manager/publish-production-r2.yaml \
+                listing update
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_CLOUDFLARE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_CLOUDFLARE_SECRET_ACCESS_KEY }}
+          GRYPE_DB_MANAGER_DISTRIBUTION_S3_ENDPOINT_URL: ${{ secrets.TOOLBOX_CLOUDFLARE_R2_ENDPOINT }}
+
+      - uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 #v3.16.2
+        with:
+          status: ${{ job.status }}
+          fields: workflow,eventName,job
+          text: Publishing the Grype DB listing file has failed
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+
+  sync-listing-file-to-s3:
+    name: "Sync listing file to S3"
+    needs:
+      - publish-listing-file
+    uses: ./.github/workflows/copy-listing-from-r2.yaml
+    secrets: inherit

--- a/manager/tests/cli/test_legacy_workflows.py
+++ b/manager/tests/cli/test_legacy_workflows.py
@@ -200,13 +200,10 @@ def test_workflow_4(cli_env, command, logger, tmp_path, grype):
     )
     assert "Quality gate passed!" in stdout
     assert "' uploaded to s3://testbucket/grype/databases" in stdout
-
-    logger.step("case 2: update the listing file based on the DB uploaded")
-
-    # update the listing file and validate
-    stdout, _ = command.run("grype-db-manager -v listing update", env=cli_env)
     assert "Validation passed" in stdout
     assert "listing.json uploaded to s3://testbucket/grype/databases" in stdout
+
+    logger.step("case 2: update the listing file based on the DB uploaded")
 
     # set grype environment variables
     cli_env.update(

--- a/uv.lock
+++ b/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "grype-db-manager"
-version = "0.28.0.post15+761a9c7"
+version = "0.28.0.post16+a94a28d"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Now that listing operations are not a shared concern between multiple schemas (v6 uploads its own listing once the db is built and uploaded) this PR merges all listing operations for v5 into the db upload step (like with v6). A new ops helper workflow has been added to re-create the listing based off of S3 state separate from a DB build in case there is a failure in prod of only this step (not the DB build and upload) which would save time when trying to get a listing fixed in prod.