### PR TITLE
Account for v prefix on schema versions

### DIFF
--- a/manager/src/grype_db_manager/db/latest.py
+++ b/manager/src/grype_db_manager/db/latest.py
@@ -59,7 +59,7 @@ class Latest:
 
 @contextlib.contextmanager
 def _http_server(directory: str, schema_version: str) -> Iterator[str]:
-    major_version = schema_version.split(".")[0]
+    major_version = schema_version.split(".")[0].removeprefix("v")
     server_address = ("127.0.0.1", 5555)
     url = f"http://{server_address[0]}:{server_address[1]}"
     latest_url = f"{url}/v{major_version}/{LATEST_FILENAME}"
@@ -142,7 +142,7 @@ def smoke_test(
 
         installation_path = os.path.join(tempdir, "grype-install")
 
-        major_version = test_latest.schema_version.split(".")[0]
+        major_version = test_latest.schema_version.split(".")[0].removeprefix("v")
 
         sub_path = os.path.join(tempdir, "v" + major_version)
         os.makedirs(sub_path, exist_ok=True)

--- a/manager/src/grype_db_manager/grype.py
+++ b/manager/src/grype_db_manager/grype.py
@@ -24,7 +24,7 @@ class Grype:
 
     def __init__(self, schema_version: int | str, store_root: str, update_url: str = "", release: str | None = None):
         if isinstance(schema_version, str):
-            schema_version = int(schema_version.split(".")[0])
+            schema_version = int(schema_version.split(".")[0].removeprefix("v"))
         self.schema_version = schema_version
         if release:
             logging.warning(f"overriding grype release for schema={schema_version!r} with release={release!r}")

--- a/manager/src/grype_db_manager/grypedb.py
+++ b/manager/src/grype_db_manager/grypedb.py
@@ -449,13 +449,13 @@ def db_metadata(build_dir: str) -> dict:
             # example data:
             # {
             #  "status": "active",
-            #  "schemaVersion": "6.0.0",
+            #  "schemaVersion": "v6.0.0",
             #  "built": "2024-11-26T20:24:24Z",
             #  "path": "vulnerability-db_v6.0.0_2024-11-25T01:31:56Z_1732652663.tar.zst",
             #  "checksum": "sha256:1a0ec0ba815083d0ef50790c8c94307c822fd7d09632dee9c3edb6bf5a58e6ff"
             # }
             return {
-                "version": int(metadata["schemaVersion"].split(".")[0]),
+                "version": int(metadata["schemaVersion"].split(".")[0].removeprefix("v")),
                 "db_checksum": "xxh64:" + db_checksum.hexdigest(),
                 "db_created": metadata["built"],
                 "data_created": parse_datetime(metadata["path"].split("_")[2]),


### PR DESCRIPTION
Schema versions expressed in v6 latest.json files now have a prefix `v`, this PR addresses this change.