### PR TITLE
Enable EPSS and KEV vunnel providers

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -15,7 +15,9 @@ provider:
     - name: amazon
     - name: chainguard
     - name: debian
+    - name: epss
     - name: github
+    - name: kev
     - name: mariner
     - name: oracle
     - name: rhel
@@ -35,4 +37,5 @@ pull:
   parallelism: 4
 
 package:
+  # required for v5
   publish-base-url: https://grype.anchore.io/databases

--- a/config/grype-db/publish-nightly.yaml
+++ b/config/grype-db/publish-nightly.yaml
@@ -15,7 +15,9 @@ provider:
     - name: amazon
     - name: chainguard
     - name: debian
+    - name: epss
     - name: github
+    - name: kev
     - name: mariner
     - name: oracle
     - name: rhel
@@ -35,4 +37,5 @@ pull:
   parallelism: 4
 
 package:
+  # required for v5
   publish-base-url: https://toolbox-data.anchore.io/grype/databases

--- a/pkg/process/build.go
+++ b/pkg/process/build.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -100,33 +101,35 @@ func build(results []providerResults, writer data.Writer, processors ...data.Pro
 	}
 	log.WithFields("total", humanize.Comma(int64(totalRecords))).Info("processing all records")
 
-	var recordsProcessed int
-
 	// for exponential moving average, choose an alpha between 0 and 1, where 1 biases towards the most recent sample
 	// and 0 biases towards the average of all samples.
 	rateWindow := newEMA(0.4)
 
+	var recordsProcessed, recordsObserved, dropped int
+	droppedElementsByProvider := make(map[string]int)
+	droppedSchemaElements := make(map[string]int)
+
 	for _, result := range results {
 		log.WithFields("provider", result.provider.Provider, "total", humanize.Comma(result.count)).Info("processing provider records")
-		providerRecordsProcessed := 0
-		recordsProcessedInStatusCycle := 0
+		providerRecordsObserved := 0
+		recordsObservedInStatusCycle := 0
 		for opener := range result.openers {
-			providerRecordsProcessed++
-			recordsProcessed++
-			recordsProcessedInStatusCycle++
+			providerRecordsObserved++
+			recordsObserved++
+			recordsObservedInStatusCycle++
 			var processor data.Processor
 
 			if time.Since(lastUpdate) > 3*time.Second {
-				r := recordsPerSecond(recordsProcessedInStatusCycle, lastUpdate)
+				r := recordsPerSecond(recordsObservedInStatusCycle, lastUpdate)
 				rateWindow.Add(r)
 
 				log.WithFields(
-					"provider", fmt.Sprintf("%q %1.0f/s (%1.2f%%)", result.provider.Provider, r, percent(providerRecordsProcessed, int(result.count))),
-					"overall", fmt.Sprintf("%1.2f%%", percent(recordsProcessed, totalRecords)),
-					"eta", eta(recordsProcessed, totalRecords, rateWindow.Average()).String(),
+					"provider", fmt.Sprintf("%q %1.0f/s (%1.2f%%)", result.provider.Provider, r, percent(providerRecordsObserved, int(result.count))),
+					"overall", fmt.Sprintf("%1.2f%%", percent(recordsObserved, totalRecords)),
+					"eta", eta(recordsObserved, totalRecords, rateWindow.Average()).String(),
 				).Debug("status")
 				lastUpdate = time.Now()
-				recordsProcessedInStatusCycle = 0
+				recordsObservedInStatusCycle = 0
 			}
 
 			f, err := opener.Open()
@@ -145,9 +148,12 @@ func build(results []providerResults, writer data.Writer, processors ...data.Pro
 				}
 			}
 			if processor == nil {
-				log.WithFields("schema", envelope.Schema).Warnf("schema is not implemented for any processor. Dropping item")
+				droppedElementsByProvider[result.provider.Provider]++
+				droppedSchemaElements[envelope.Schema]++
+				dropped++
 				continue
 			}
+			recordsProcessed++
 
 			entries, err := processor.Process(bytes.NewReader(envelope.Item), result.provider)
 			if err != nil {
@@ -160,9 +166,35 @@ func build(results []providerResults, writer data.Writer, processors ...data.Pro
 		}
 	}
 
-	log.Debugf("wrote all provider state")
+	logDropped(droppedElementsByProvider, droppedSchemaElements)
+
+	log.WithFields("processed", recordsProcessed, "dropped", dropped, "observed", recordsObserved).Debugf("wrote all provider state")
+
+	if recordsProcessed == 0 {
+		return fmt.Errorf("no records were processed")
+	}
 
 	return nil
+}
+
+func logDropped(droppedElementsByProvider, droppedSchemaElements map[string]int) {
+	sortedKeys := func(m map[string]int) []string {
+		var keys []string
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return keys
+	}
+	sortedProviders := sortedKeys(droppedElementsByProvider)
+	for _, p := range sortedProviders {
+		log.WithFields("provider", p, "count", droppedElementsByProvider[p]).Warn("dropped records for provider")
+	}
+
+	sortedSchemas := sortedKeys(droppedSchemaElements)
+	for _, s := range sortedSchemas {
+		log.WithFields("schema", s, "count", droppedSchemaElements[s]).Warn("dropped records by schema")
+	}
 }
 
 type expMovingAverage struct {


### PR DESCRIPTION
This adds the [EPSS and KEV providers](https://github.com/anchore/vunnel/releases/tag/v0.31.0) to the nightly publish configs. This additionally changes how unprocessed records are logged. Today we log a schema reference for all records not processed, however, this results in a lot of logs that say the same thing in the case where a provider is not supported by a particular schema version (in this case schema v5 with EPSS and KEV providers). The presentation has been changed to show the number of unprocessed records for each schema and provider to the logs. Also, if no records were processed then the build process now will fail (`build` will have a return code of 1).


# TODO
- I need to [rerun the data sync for today](https://github.com/anchore/grype-db/actions/runs/13525928541) based off of this branch to hydrate the vunnel data cache used for acceptance tests (CI will fail until then)