### PR TITLE
fix: pin grype to v0.87.0 for v5

### DIFF
--- a/manager/src/grype_db_manager/data/schema-info.json
+++ b/manager/src/grype_db_manager/data/schema-info.json
@@ -22,7 +22,7 @@
     },
     {
       "schema": "5",
-      "grype-version": "main",
+      "grype-version": "v0.87.0",
       "supported": true
     },
     {

--- a/manager/tests/unit/db/test_schema.py
+++ b/manager/tests/unit/db/test_schema.py
@@ -10,7 +10,8 @@ def test_grype_version():
     assert "v0.12.1" == schema.grype_version(2)
     assert "v0.40.1" == schema.grype_version(3)
     assert "v0.50.2" == schema.grype_version(4)
-    assert "main" == schema.grype_version(5)
+    assert "v0.87.0" == schema.grype_version(5)
+    assert "main" == schema.grype_version(6)
 
 
 def test_supported_schema_versions():


### PR DESCRIPTION
This PR pins grype for v5 to the latest version which supports it: v0.87.0