### PR TITLE
Enable v6 CI validations

### DIFF
--- a/.grype-v6.yaml
+++ b/.grype-v6.yaml
@@ -1,3 +1,0 @@
-# TODO: delete me once v6 lands on grype@main without a feature flag
-exp:
-  dbv6: true

--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -10,7 +10,9 @@ expected-providers:
   - amazon
   - chainguard
   - debian
+  - epss
   - github
+  - kev
   - mariner
   - nvd
   - oracle

--- a/manager/src/grype_db_manager/cli/db.py
+++ b/manager/src/grype_db_manager/cli/db.py
@@ -169,18 +169,16 @@ def _validate_db(
 
     yardstick_profile_data = ycfg.Profiles()
     profile_name = None
-    if db_info.schema_version >= 6:
-        # TODO: we don't have any published v6 grype databases yet
-        basis_grype_version = db.schema.grype_version(5)
-        # TODO: we can remove this once v6 lands on grype@main without a feature flag
-        profile_name = f"v{db_info.schema_version}"
-        yardstick_profile_data = ycfg.Profiles(
-            data={
-                "grype[custom-db]": {
-                    profile_name: {"config_path": f"./.grype-v{db_info.schema_version}.yaml"},
-                },
-            },
-        )
+    # this is a good example of how to add a custom profile configuration by a profile when working on a new schema version
+    # if db_info.schema_version >= 6:
+    #     profile_name = f"v{db_info.schema_version}"
+    #     yardstick_profile_data = ycfg.Profiles(
+    #         data={
+    #             "grype[custom-db]": {
+    #                 profile_name: {"config_path": f"./.grype-v{db_info.schema_version}.yaml"},
+    #             },
+    #         },
+    #     )
 
     result_sets = {}
     for idx, rs in enumerate(cfg.validate.gates):

--- a/manager/src/grype_db_manager/data/schema-info.json
+++ b/manager/src/grype_db_manager/data/schema-info.json
@@ -28,8 +28,7 @@
     {
       "schema": "6",
       "grype-version": "main",
-      "supported": true,
-      "validate": false
+      "supported": true
     }
   ]
 }

--- a/manager/src/grype_db_manager/grype.py
+++ b/manager/src/grype_db_manager/grype.py
@@ -48,12 +48,6 @@ class Grype:
     def _env(self, env: dict[str, str] | None = None) -> dict[str, str]:
         if not env:
             env = os.environ.copy()
-        if self.schema_version >= 6:
-            env.update(
-                {
-                    "GRYPE_EXP_DBV6": "true",
-                },
-            )
         return env
 
     def update_db(self) -> None:

--- a/manager/tests/cli/.gitignore
+++ b/manager/tests/cli/.gitignore
@@ -2,5 +2,6 @@ cli-test-data*
 .yardstick
 .grype-db-manager
 grype-db-cache.tar.gz
+grype-db-cache.tar.zst
 venv
 bin

--- a/manager/tests/cli/.grype-v6.yaml
+++ b/manager/tests/cli/.grype-v6.yaml
@@ -1,3 +1,0 @@
-# TODO: delete me once v6 lands on grype@main without a feature flag
-exp:
-  dbv6: true

--- a/manager/tests/cli/test_workflows.py
+++ b/manager/tests/cli/test_workflows.py
@@ -22,7 +22,6 @@ def test_workflow_1(cli_env, command, logger, tmp_path, grype):
             "AWS_ACCESS_KEY_ID": "test",
             "AWS_SECRET_ACCESS_KEY": "test",
             "AWS_REGION": "us-west-2",
-            "GRYPE_EXP_DBV6": "true",  # while we are in development, we need to enable the experimental dbv6 feature flag
             "GRYPE_DB_AUTO_UPDATE": "false",  # disable auto-updating the database to avoid unexpected behavior
             "GOWORK": "off",  # workaround for Go 1.23+ parent directory module lookup
             "PATH": f"{bin_dir}:{cli_env['PATH']}",  # ensure `bin` directory is in PATH

--- a/pkg/process/default_schema_version.go
+++ b/pkg/process/default_schema_version.go
@@ -1,7 +1,5 @@
 package process
 
-import grypeDB "github.com/anchore/grype/grype/db/v5"
+import grypeDB "github.com/anchore/grype/grype/db/v6"
 
-// TODO: stay on v5 until v6 is dev-complete
-
-const DefaultSchemaVersion = grypeDB.SchemaVersion
+const DefaultSchemaVersion = grypeDB.ModelVersion


### PR DESCRIPTION
This will include v6 acceptance tests and other DB validations while removing the use of v6 feature flags used in development