### PR TITLE
chore: update grype schema version reference

### DIFF
--- a/cmd/grype-db/application/build_info.go
+++ b/cmd/grype-db/application/build_info.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"runtime/debug"
 
-	grypeDB "github.com/anchore/grype/grype/db"
+	grypeDB "github.com/anchore/grype/grype/db/v6"
 )
 
 const valueNotProvided = "[not provided]"
@@ -70,6 +70,6 @@ func ReadBuildInfo() BuildInfo {
 		GoVersion:      runtime.Version(),
 		Compiler:       runtime.Compiler,
 		Platform:       platform,
-		DBSchema:       grypeDB.SchemaVersion,
+		DBSchema:       grypeDB.ModelVersion,
 	}
 }


### PR DESCRIPTION
This PR updates the Grype schema version reference to v6