### PR TITLE
Add hardware and operating system CPE parts

### DIFF
--- a/pkg/process/v6/transformers/nvd/transform.go
+++ b/pkg/process/v6/transformers/nvd/transform.go
@@ -23,7 +23,7 @@ type Config struct {
 
 func defaultConfig() Config {
 	return Config{
-		CPEParts:            strset.New("a"),
+		CPEParts:            strset.New("a", "h", "o"),
 		InferNVDFixVersions: true,
 	}
 }

--- a/pkg/process/v6/transformers/nvd/unique_pkg_test.go
+++ b/pkg/process/v6/transformers/nvd/unique_pkg_test.go
@@ -50,7 +50,7 @@ func TestFindUniquePkgs(t *testing.T) {
 				}),
 		},
 		{
-			name: "skip-hw",
+			name: "include-hw",
 			nodes: []nvd.Node{
 				{
 					CpeMatch: []nvd.CpeMatch{
@@ -61,10 +61,16 @@ func TestFindUniquePkgs(t *testing.T) {
 					},
 				},
 			},
-			expected: newUniquePkgTrackerFromSlice([]pkgCandidate{}),
+			expected: newUniquePkgTrackerFromSlice([]pkgCandidate{
+				{
+					Product:        "product",
+					Vendor:         "vendor",
+					TargetSoftware: "target",
+				},
+			}),
 		},
 		{
-			name: "skip-os",
+			name: "include-os",
 			nodes: []nvd.Node{
 				{
 					CpeMatch: []nvd.CpeMatch{
@@ -75,7 +81,13 @@ func TestFindUniquePkgs(t *testing.T) {
 					},
 				},
 			},
-			expected: newUniquePkgTrackerFromSlice([]pkgCandidate{}),
+			expected: newUniquePkgTrackerFromSlice([]pkgCandidate{
+				{
+					Product:        "product",
+					Vendor:         "vendor",
+					TargetSoftware: "target",
+				},
+			}),
 		},
 		{
 			name: "duplicate-by-product",


### PR DESCRIPTION
Related to https://github.com/anchore/grype/issues/2365 , adds all CPEs from NVD to the DB, where previously we only added `a` types.