### PR TITLE
Fix processing of github-action entries

### DIFF
--- a/pkg/process/v5/transformers/github/transform_test.go
+++ b/pkg/process/v5/transformers/github/transform_test.go
@@ -22,6 +22,7 @@ func TestBuildGrypeNamespace(t *testing.T) {
 	tests := []struct {
 		group     string
 		namespace namespace.Namespace
+		wantErr   require.ErrorAssertionFunc
 	}{
 		{
 			group:     "github:python",
@@ -51,12 +52,24 @@ func TestBuildGrypeNamespace(t *testing.T) {
 			group:     "github:rust",
 			namespace: language.NewNamespace("github", syftPkg.Rust, ""),
 		},
+		{
+			group: "github:github-action",
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				assert.Error(t, err)
+				assert.ErrorIs(t, errSkip, err)
+			},
+		},
 	}
 
 	for _, test := range tests {
+		if test.wantErr == nil {
+			test.wantErr = require.NoError
+		}
 		ns, err := buildGrypeNamespace(test.group)
-
-		assert.NoError(t, err)
+		test.wantErr(t, err)
+		if err != nil {
+			return
+		}
 		assert.Equal(t, test.namespace, ns)
 	}
 }

--- a/pkg/process/v6/transformers/github/transform.go
+++ b/pkg/process/v6/transformers/github/transform.go
@@ -164,6 +164,12 @@ func getPackageType(ecosystem string) pkg.Type {
 		return pkg.RpmPkg
 	case "deb":
 		return pkg.DebPkg
+	case "github-action":
+		return pkg.GithubActionPkg
+	}
+	ty := pkg.TypeByName(ecosystem)
+	if ty != pkg.UnknownPkg {
+		return ty
 	}
 
 	log.Warnf("using unknown ecosystem intead of syft pkg type (this will probably cause issues when matching): %q", ecosystem)

--- a/pkg/process/v6/transformers/github/transform_test.go
+++ b/pkg/process/v6/transformers/github/transform_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anchore/grype-db/pkg/provider"
 	"github.com/anchore/grype-db/pkg/provider/unmarshal"
 	grypeDB "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/syft/syft/pkg"
 )
 
 func TestTransform(t *testing.T) {
@@ -538,6 +539,51 @@ func TestGetAffectedPackage(t *testing.T) {
 			}
 			if d := cmp.Diff(tt.expected, results); d != "" {
 				t.Fatalf("unexpected result: %s", d)
+			}
+		})
+	}
+}
+
+func TestGetPackageType(t *testing.T) {
+	tests := []struct {
+		ecosystem    string
+		expectedType pkg.Type
+	}{
+		{"composer", pkg.PhpComposerPkg},
+		{"Composer", pkg.PhpComposerPkg}, // testing case insensitivity
+		{"COMPOSER", pkg.PhpComposerPkg}, // testing case insensitivity
+		{"rust", pkg.RustPkg},
+		{"cargo", pkg.RustPkg},
+		{"dart", pkg.DartPubPkg},
+		{"nuget", pkg.DotnetPkg},
+		{".net", pkg.DotnetPkg},
+		{"go", pkg.GoModulePkg},
+		{"golang", pkg.GoModulePkg},
+		{"maven", pkg.JavaPkg},
+		{"java", pkg.JavaPkg},
+		{"npm", pkg.NpmPkg},
+		{"pypi", pkg.PythonPkg},
+		{"python", pkg.PythonPkg},
+		{"pip", pkg.PythonPkg},
+		{"swift", pkg.SwiftPkg},
+		{"rubygems", pkg.GemPkg},
+		{"ruby", pkg.GemPkg},
+		{"gem", pkg.GemPkg},
+		{"apk", pkg.ApkPkg},
+		{"rpm", pkg.RpmPkg},
+		{"deb", pkg.DebPkg},
+		{"github-action", pkg.GithubActionPkg},
+
+		// test for unknown type fallback
+		{"unknown-ecosystem", pkg.Type("unknown-ecosystem")},
+		{"", pkg.Type("")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.ecosystem, func(t *testing.T) {
+			gotType := getPackageType(tc.ecosystem)
+			if gotType != tc.expectedType {
+				t.Errorf("getPackageType(%q) = %v, want %v", tc.ecosystem, gotType, tc.expectedType)
 			}
 		})
 	}


### PR DESCRIPTION
This effectively adds github-action advisories, however, they are disabled in v5 (as there is no version of grype that can effectively match on it).