### PR TITLE
feat: add field to ignore-provider-date for long term broken providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ provider:
   # names of providers to filter down to while running
   # same as -p
   include-filter: []
-  
+    
   vunnel:
     # how to execute vunnel. Options are:
     #  - "docker" (default): execute vunnel in a docker container
@@ -288,6 +288,11 @@ build:
 
   # skip validation of the provider state
   skip-validation: false
+
+  # names of providers to ignore build dates for
+  # useful for when there are extended outages for data providers and you want
+  # a more recent date for the v5 grype-db
+  ignore-provider-date: []
 
 package:
   # this is the base URL that is referenced in the listing file created during the "package" command

--- a/cmd/grype-db/cli/commands/build.go
+++ b/cmd/grype-db/cli/commands/build.go
@@ -107,7 +107,7 @@ func runBuild(cfg buildConfig) error {
 		return fmt.Errorf("unable to get provider states: %w", err)
 	}
 
-	earliest, err := provider.States(states).EarliestTimestamp()
+	earliest, err := provider.States(states).EarliestTimestamp(cfg.IgnoreProviderDate)
 	if err != nil {
 		return fmt.Errorf("unable to get earliest timestamp: %w", err)
 	}

--- a/cmd/grype-db/cli/options/build.go
+++ b/cmd/grype-db/cli/options/build.go
@@ -17,6 +17,7 @@ type Build struct {
 	SchemaVersion  int  `yaml:"schema-version" json:"schema-version" mapstructure:"schema-version"`
 
 	// unbound options
+	IgnoreProviderDate  []string `yaml:"ignore-provider-date" json:"ignore-provider-date" mapstructure:"ignore-provider-date"`
 	IncludeCPEParts     []string `yaml:"include-cpe-parts" json:"include-cpe-parts" mapstructure:"include-cpe-parts"`
 	InferNVDFixVersions bool     `yaml:"infer-nvd-fix-versions" json:"infer-nvd-fix-versions" mapstructure:"infer-nvd-fix-versions"`
 	Hydrate             bool     `yaml:"hydrate" json:"hydrate" mapstructure:"hydrate"`

--- a/pkg/provider/state_test.go
+++ b/pkg/provider/state_test.go
@@ -10,10 +10,11 @@ import (
 
 func Test_earliestTimestamp(t *testing.T) {
 	tests := []struct {
-		name    string
-		states  []State
-		want    time.Time
-		wantErr require.ErrorAssertionFunc
+		name               string
+		states             []State
+		want               time.Time
+		ignoreProviderDate []string
+		wantErr            require.ErrorAssertionFunc
 	}{
 		{
 			name: "happy path",
@@ -89,6 +90,25 @@ func Test_earliestTimestamp(t *testing.T) {
 			want: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
 		},
 		{
+			name: "filter specific provider from config",
+			states: []State{
+				{
+					Provider:  "nvd",
+					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Provider:  "filterMe",
+					Timestamp: time.Date(2020, 1, 3, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Provider:  "other",
+					Timestamp: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			ignoreProviderDate: []string{"filterMe"},
+			want:               time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
 			name: "timestamps are the same",
 			states: []State{
 				{
@@ -110,7 +130,7 @@ func Test_earliestTimestamp(t *testing.T) {
 			if tt.wantErr == nil {
 				tt.wantErr = require.NoError
 			}
-			got, err := States(tt.states).EarliestTimestamp()
+			got, err := States(tt.states).EarliestTimestamp(tt.ignoreProviderDate)
 			tt.wantErr(t, err)
 			if err != nil {
 				return


### PR DESCRIPTION
## Description
This PR adds a new field to the grype-db config: `build.ignore-provider-date`

This field will be used when calculating the earliest timestamp when building the db. 

`grype-db` will ignore user specified providers that may have been broken for extended periods of time. This allows the `earliest` date to be calculated for a more recent provider. This calculation would update the db date to be in compliance with checks like `max-allowed-built-age` when running https://github.com/anchore/grype.