### PR TITLE
Revert "feat: enable bitnami vuln data"

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -13,7 +13,6 @@ provider:
     - name: nvd
     - name: alpine
     - name: amazon
-    - name: bitnami
     - name: chainguard
     - name: debian
     - name: epss


### PR DESCRIPTION
Reverts anchore/grype-db#581

This change causes db publish failures: https://github.com/anchore/grype-db/actions/runs/15401442015/job/43334751298

Attempts to roll forward quickly have proven that there are complexities to adding v6-only providers, since this has never been done before, see https://github.com/anchore/grype-db/pull/582

Therefore, revert until we figure this out, so that tonight's grype-db publishes normally.

(edit: force pushed to fix DCO - apparently GH UI "revert" button doesn't sign-off commits, or I didn't know how to tell it to.)

