### PR TITLE
fix: include CVSS version in vector string

### DIFF
--- a/pkg/process/v6/transformers/osv/transform.go
+++ b/pkg/process/v6/transformers/osv/transform.go
@@ -256,7 +256,7 @@ func extractCVSSInfo(cvss string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid CVSS format")
 	}
 
-	return matches[1], matches[2], nil
+	return matches[1], matches[0], nil
 }
 
 func normalizeSeverity(severity models.Severity) (grypeDB.Severity, error) {

--- a/pkg/process/v6/transformers/osv/transform_test.go
+++ b/pkg/process/v6/transformers/osv/transform_test.go
@@ -95,7 +95,7 @@ func TestTransform(t *testing.T) {
 						Severities: []grypeDB.Severity{{
 							Scheme: grypeDB.SeveritySchemeCVSS,
 							Value: grypeDB.CVSSSeverity{
-								Vector:  "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+								Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 								Version: "3.1",
 							},
 						}},
@@ -145,7 +145,7 @@ func TestTransform(t *testing.T) {
 						Severities: []grypeDB.Severity{{
 							Scheme: grypeDB.SeveritySchemeCVSS,
 							Value: grypeDB.CVSSSeverity{
-								Vector:  "AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+								Vector:  "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
 								Version: "3.1",
 							},
 						}},
@@ -402,7 +402,7 @@ func Test_extractCVSSInfo(t *testing.T) {
 			name:        "valid cvss",
 			cvss:        "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 			wantVersion: "3.1",
-			wantVector:  "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			wantVector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 			wantErr:     false,
 		},
 		{


### PR DESCRIPTION
Previously, the CVSS vector would have the version prefix removed before serialization to the vulnerability blob, preventing Grype from parsing the vector into a severity to display. Instead retain the whole vector.

Fixes https://github.com/anchore/grype/issues/2725