### PR TITLE
get severity for GHSAs missing it

### DIFF
--- a/pkg/process/v6/writer.go
+++ b/pkg/process/v6/writer.go
@@ -142,7 +142,7 @@ func (w *writer) fillInMissingSeverity(handle *grypeDB.VulnerabilityHandle) {
 	id := strings.ToLower(blob.ID)
 	isCVE := strings.HasPrefix(id, "cve-")
 	isGHSA := strings.HasPrefix(id, "ghsa-")
-	
+
 	// Cache severity data from NVD (for CVEs) and GitHub (for GHSAs)
 	providerID := strings.ToLower(handle.ProviderID)
 	if providerID == "nvd" && isCVE {
@@ -151,7 +151,7 @@ func (w *writer) fillInMissingSeverity(handle *grypeDB.VulnerabilityHandle) {
 		}
 		return
 	}
-	
+
 	if providerID == "github" && isGHSA {
 		if len(blob.Severities) > 0 {
 			w.severityCache[id] = blob.Severities[0]

--- a/pkg/process/v6/writer_test.go
+++ b/pkg/process/v6/writer_test.go
@@ -32,10 +32,10 @@ func TestFillInMissingSeverity(t *testing.T) {
 			expected:      nil,
 		},
 		{
-			name: "non-CVE ID",
+			name: "non-CVE/non-GHSA ID",
 			handle: &grypeDB.VulnerabilityHandle{
 				BlobValue: &grypeDB.VulnerabilityBlob{
-					ID: "GHSA-123",
+					ID: "OTHER-123",
 					Severities: []grypeDB.Severity{
 						{Value: "high"},
 					},
@@ -57,6 +57,21 @@ func TestFillInMissingSeverity(t *testing.T) {
 			},
 			severityCache:     map[string]grypeDB.Severity{},
 			expected:          []grypeDB.Severity{{Value: "critical"}},
+			expectCacheUpdate: true,
+		},
+		{
+			name: "GitHub provider with GHSA",
+			handle: &grypeDB.VulnerabilityHandle{
+				ProviderID: "github",
+				BlobValue: &grypeDB.VulnerabilityBlob{
+					ID: "GHSA-1234-5678-9abc",
+					Severities: []grypeDB.Severity{
+						{Value: "high"},
+					},
+				},
+			},
+			severityCache:     map[string]grypeDB.Severity{},
+			expected:          []grypeDB.Severity{{Value: "high"}},
 			expectCacheUpdate: true,
 		},
 		{
@@ -92,6 +107,20 @@ func TestFillInMissingSeverity(t *testing.T) {
 				"cve-2023-9012": {Value: "high"},
 			},
 			expected: []grypeDB.Severity{{Value: "high"}},
+		},
+		{
+			name: "GHSA with no severities, using cache",
+			handle: &grypeDB.VulnerabilityHandle{
+				ProviderID: "alpine",
+				BlobValue: &grypeDB.VulnerabilityBlob{
+					ID:         "GHSA-abcd-efgh-ijkl",
+					Severities: []grypeDB.Severity{},
+				},
+			},
+			severityCache: map[string]grypeDB.Severity{
+				"ghsa-abcd-efgh-ijkl": {Value: "medium"},
+			},
+			expected: []grypeDB.Severity{{Value: "medium"}},
 		},
 	}
 

--- a/pkg/provider/providers/providers_test.go
+++ b/pkg/provider/providers/providers_test.go
@@ -1,0 +1,118 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/grype-db/pkg/provider"
+	"github.com/anchore/grype-db/pkg/provider/providers/vunnel"
+)
+
+// mockProvider is a simple mock implementation of provider.Provider for testing
+type mockProvider struct {
+	name string
+}
+
+func (m mockProvider) ID() provider.Identifier {
+	return provider.Identifier{Name: m.name}
+}
+
+func (m mockProvider) GetProviderState() provider.State {
+	return provider.State{}
+}
+
+func (m mockProvider) GetSchemaVersion() int {
+	return 1
+}
+
+func (m mockProvider) GetWorkspace() string {
+	return ""
+}
+
+func (m mockProvider) Close() error {
+	return nil
+}
+
+func TestNew_ProviderOrdering(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerNames    []string
+		expectedOrdering []string
+	}{
+		{
+			name:             "nvd first, github second",
+			providerNames:    []string{"other1", "github", "nvd", "other2"},
+			expectedOrdering: []string{"nvd", "github", "other1", "other2"},
+		},
+		{
+			name:             "only nvd",
+			providerNames:    []string{"nvd"},
+			expectedOrdering: []string{"nvd"},
+		},
+		{
+			name:             "only github",
+			providerNames:    []string{"github"},
+			expectedOrdering: []string{"github"},
+		},
+		{
+			name:             "no nvd or github",
+			providerNames:    []string{"other1", "other2", "other3"},
+			expectedOrdering: []string{"other1", "other2", "other3"},
+		},
+		{
+			name:             "nvd and github only",
+			providerNames:    []string{"github", "nvd"},
+			expectedOrdering: []string{"nvd", "github"},
+		},
+		{
+			name:             "multiple others with nvd and github",
+			providerNames:    []string{"alpine", "github", "debian", "nvd", "ubuntu", "centos"},
+			expectedOrdering: []string{"nvd", "github", "alpine", "debian", "ubuntu", "centos"},
+		},
+		{
+			name:             "reverse alphabetical input",
+			providerNames:    []string{"ubuntu", "nvd", "github", "debian", "alpine"},
+			expectedOrdering: []string{"nvd", "github", "ubuntu", "debian", "alpine"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock configs for each provider name
+			var configs []provider.Config
+			for _, name := range tt.providerNames {
+				configs = append(configs, provider.Config{
+					Identifier: provider.Identifier{
+						Name: name,
+						Kind: provider.VunnelKind,
+					},
+				})
+			}
+
+			// Call New with mock vunnel config
+			vCfg := vunnel.Config{
+				GenerateConfigs: false, // Don't generate additional configs for this test
+			}
+
+			providers, err := New("test-root", vCfg, configs...)
+			require.NoError(t, err)
+			require.Len(t, providers, len(tt.expectedOrdering))
+
+			// Verify the ordering
+			var actualOrdering []string
+			for _, p := range providers {
+				actualOrdering = append(actualOrdering, p.ID().Name)
+			}
+
+			require.Equal(t, tt.expectedOrdering, actualOrdering)
+		})
+	}
+}
+
+func TestNew_EmptyConfigs(t *testing.T) {
+	vCfg := vunnel.Config{GenerateConfigs: false}
+	_, err := New("test-root", vCfg)
+	require.Error(t, err)
+	require.Equal(t, ErrNoProviders, err)
+}


### PR DESCRIPTION
Sometimes secDB using distros include information that a given package version fixed a GHSA. This causes a GHSA match with no severity to be emitted by grype.

In the case that a provider other than the GitHub provider emits a vulnerability with GHSA ID, copy the severity from GitHub.

This is related to https://github.com/anchore/grype/issues/2691 but is only a partial fix. Sometimes SecDB using distros will publish that they have fixed an unreviewed GHSA. This change does not address that situation, because unreviewed GHSAs are not present in the data set, and so this will not be able to copy a severity for one. (Also, GitHub have likely not assigned a severity to an unreviewed GHSA anyway.)

A better approach might be to make the Wolfi vunnel provider know about the GitHub data, and have it fetch the _alias_ field from the GHSA, and put the severity from the CVE that's an alias of the GHSA in its output, see https://github.com/anchore/grype/issues/2691#issuecomment-2989056216