### PR TITLE
fix: update workflow call block to avoid inheriting secrets

### DIFF
--- a/.github/workflows/copy-listing-from-r2.yaml
+++ b/.github/workflows/copy-listing-from-r2.yaml
@@ -5,6 +5,13 @@ on:
 
   # allow invoking from another workflow
   workflow_call:
+    secrets:
+      TOOLBOX_AWS_ACCESS_KEY_ID:
+        required: true
+      TOOLBOX_AWS_SECRET_ACCESS_KEY:
+        required: true
+      SLACK_TOOLBOX_WEBHOOK_URL:
+        required: true
 
 env:
   CGO_ENABLED: "0"


### PR DESCRIPTION
Otherwise calling this workflow with explicitly passed secrets will fail, and calling it with inherited secrets makes the linter unhappy.

Otherwise we see failures like https://github.com/anchore/grype-db/actions/runs/16322322588:

[Invalid workflow file: .github/workflows/daily-db-publisher-r2.yaml#L166](https://github.com/anchore/grype-db/actions/runs/16322322588/workflow)
The workflow is not valid. .github/workflows/daily-db-publisher-r2.yaml (Line: 166, Col: 34): Invalid secret, TOOLBOX_AWS_ACCESS_KEY_ID is not defined in the referenced workflow. .github/workflows/daily-db-publisher-r2.yaml (Line: 167, Col: 38): Invalid secret, TOOLBOX_AWS_SECRET_ACCESS_KEY is not defined in the referenced workflow.