### PR TITLE
fix: incorrect associations between affected ranges and CPE

### DIFF
--- a/pkg/process/v6/transformers/nvd/test-fixtures/CVE-2004-0377.json
+++ b/pkg/process/v6/transformers/nvd/test-fixtures/CVE-2004-0377.json
@@ -1,0 +1,57 @@
+{
+    "cve": {
+      "id": "CVE-2004-0377",
+      "sourceIdentifier": "cve@mitre.org",
+      "published": "2004-05-04T04:00:00.000",
+      "lastModified": "2025-04-03T01:03:51.193",
+      "vulnStatus": "Deferred",
+      "cveTags": [],
+      "descriptions": [
+        {
+          "lang": "en",
+          "value": "Buffer overflow in the win32_stat function for (1) ActiveState's ActivePerl and (2) Larry Wall's Perl before 5.8.3 allows local or remote attackers to execute arbitrary commands via filenames that end in a backslash character."
+        },
+        {
+          "lang": "es",
+          "value": "Desbordamiento de búfer en la función win32_stat de \r\n\r\nActivePerl de ActiveState, y \r\nPerl de Larry Wall anterior a 5.8.3\r\n\r\npermite a atacantes remotos ejecutar comandos arbitrarios mediante nombres de fichero que terminan en un carácter \"\" (barra invertida)."
+        }
+      ],
+      "metrics": {},
+      "weaknesses": [
+        {
+          "source": "nvd@nist.gov",
+          "type": "Primary",
+          "description": [
+            {
+              "lang": "en",
+              "value": "NVD-CWE-Other"
+            }
+          ]
+        }
+      ],
+      "configurations": [
+        {
+          "nodes": [
+            {
+              "operator": "OR",
+              "negate": false,
+              "cpeMatch": [
+                {
+                  "vulnerable": true,
+                  "criteria": "cpe:2.3:a:activestate:activeperl:*:*:*:*:*:*:*:*",
+                  "matchCriteriaId": "86BADAC0-8A7B-4348-A78C-BAAFD8A784FE"
+                },
+                {
+                  "vulnerable": true,
+                  "criteria": "cpe:2.3:a:larry_wall:perl:*:*:*:*:*:*:*:*",
+                  "versionEndIncluding": "5.8.3",
+                  "matchCriteriaId": "6851ACEC-141C-40B2-B6E1-CD52D979CE37"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": []
+    }
+  }

--- a/pkg/process/v6/transformers/nvd/transform_test.go
+++ b/pkg/process/v6/transformers/nvd/transform_test.go
@@ -1394,7 +1394,7 @@ func TestTransform(t *testing.T) {
 							ID:          "CVE-2004-0377",
 							Assigners:   []string{"cve@mitre.org"},
 							Description: "Buffer overflow in the win32_stat function for (1) ActiveState's ActivePerl and (2) Larry Wall's Perl before 5.8.3 allows local or remote attackers to execute arbitrary commands via filenames that end in a backslash character.",
-							References:  []grypeDB.Reference{
+							References: []grypeDB.Reference{
 								{
 									URL: "https://nvd.nist.gov/vuln/detail/CVE-2004-0377",
 								},
@@ -1404,9 +1404,9 @@ func TestTransform(t *testing.T) {
 					Related: affectedPkgSlice(
 						grypeDB.AffectedCPEHandle{
 							BlobValue: &grypeDB.AffectedPackageBlob{
-								CVEs: []string{"CVE-2004-0377"},
+								CVEs:   []string{"CVE-2004-0377"},
 								Ranges: nil,
-								},
+							},
 							CPE: &grypeDB.Cpe{
 								Part:    "a",
 								Vendor:  "activestate",

--- a/pkg/process/v6/transformers/nvd/transform_test.go
+++ b/pkg/process/v6/transformers/nvd/transform_test.go
@@ -1376,6 +1376,64 @@ func TestTransform(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "https://github.com/anchore/grype/issues/2807#issuecomment-3101447594",
+			fixture:  "test-fixtures/CVE-2004-0377.json",
+			provider: "nvd",
+			config:   defaultConfig(),
+			want: []transformers.RelatedEntries{
+				{
+					VulnerabilityHandle: &grypeDB.VulnerabilityHandle{
+						Name:          "CVE-2004-0377",
+						ProviderID:    "nvd",
+						Provider:      expectedProvider("nvd"),
+						ModifiedDate:  timeRef(time.Date(2025, 4, 3, 1, 3, 51, 193000000, time.UTC)),
+						PublishedDate: timeRef(time.Date(2004, 5, 4, 4, 0, 0, 0, time.UTC)),
+						Status:        grypeDB.UnknownVulnerabilityStatus,
+						BlobValue: &grypeDB.VulnerabilityBlob{
+							ID:          "CVE-2004-0377",
+							Assigners:   []string{"cve@mitre.org"},
+							Description: "Buffer overflow in the win32_stat function for (1) ActiveState's ActivePerl and (2) Larry Wall's Perl before 5.8.3 allows local or remote attackers to execute arbitrary commands via filenames that end in a backslash character.",
+							References:  []grypeDB.Reference{
+								{
+									URL: "https://nvd.nist.gov/vuln/detail/CVE-2004-0377",
+								},
+							},
+						},
+					},
+					Related: affectedPkgSlice(
+						grypeDB.AffectedCPEHandle{
+							BlobValue: &grypeDB.AffectedPackageBlob{
+								CVEs: []string{"CVE-2004-0377"},
+								Ranges: nil,
+								},
+							CPE: &grypeDB.Cpe{
+								Part:    "a",
+								Vendor:  "activestate",
+								Product: "activeperl",
+							},
+						},
+						grypeDB.AffectedCPEHandle{
+							BlobValue: &grypeDB.AffectedPackageBlob{
+								CVEs: []string{"CVE-2004-0377"},
+								Ranges: []grypeDB.AffectedRange{
+									{
+										Version: grypeDB.AffectedVersion{
+											Constraint: "<= 5.8.3",
+										},
+									},
+								},
+							},
+							CPE: &grypeDB.Cpe{
+								Part:    "a",
+								Vendor:  "larry_wall",
+								Product: "perl",
+							},
+						},
+					),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
There is a bug in the v6 processing logic that can cause affected version ranges to be associated with the incorrect CPEs within a node configuration.

Fixes https://github.com/anchore/grype/issues/2807