### PR TITLE
Persist github auth for tag step during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,8 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
-          persist-credentials: false
+          # we need to persist credentials so that we can push the tag
+          persist-credentials: true
           fetch-depth: 0
 
       - name: Bootstrap environment


### PR DESCRIPTION
This is a follow up to the zizmore linter changes made -- we need to be able to push tags during releases, which requires persisting credentials