### PR TITLE
chore: skip main repo workflows in forks

### DIFF
--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -6,6 +6,7 @@ on:
   # run 1 AM (UTC) daily
   schedule:
     - cron:  '0 1 * * *'
+
 env:
   CGO_ENABLED: "0"
   SLACK_NOTIFICATIONS: true
@@ -14,6 +15,7 @@ jobs:
   discover-providers:
     name: "Discover vulnerability providers"
     runs-on: ubuntu-24.04
+    if: github.repository == 'anchore/grype-db' # only run for main repo
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -28,7 +28,7 @@ jobs:
     # note about workflow dispatch inputs and booleans:
     # a) booleans come across as string types :(
     # b) if not using workflow_dispatch the default values are empty, which means we want these to effectively evaluate to true (so only check the negative case)
-    if: ${{ github.event.inputs.publish-databases != 'false' }}
+    if: ${{ github.event.inputs.publish-databases != 'false' && github.repository == 'anchore/grype-db'}} # only run for main repo
     name: "Pull vulnerability data"
     runs-on: ubuntu-24.04
     outputs:


### PR DESCRIPTION
This PR updates the data sync and db build and publish workflows to only run in the main repo [instead of forks](https://github.com/kzantow-anchore/grype-db/actions).