### PR TITLE
Add custom compressor commands to the config

### DIFF
--- a/cmd/grype-db/cli/commands/package.go
+++ b/cmd/grype-db/cli/commands/package.go
@@ -58,5 +58,5 @@ func Package(app *application.Application) *cobra.Command {
 }
 
 func runPackage(cfg packageConfig) error {
-	return process.Package(cfg.Directory, cfg.PublishBaseURL, cfg.OverrideArchiveExtension)
+	return process.Package(cfg.Directory, cfg.PublishBaseURL, cfg.OverrideArchiveExtension, cfg.CompressorCommands)
 }

--- a/cmd/grype-db/cli/options/package.go
+++ b/cmd/grype-db/cli/options/package.go
@@ -9,11 +9,12 @@ var _ Interface = &Package{}
 
 type Package struct {
 	// bound options
-	PublishBaseURL           string `yaml:"publish-base-url" json:"publish-base-url" mapstructure:"publish-base-url"`
-	OverrideArchiveExtension string `yaml:"override-archive-extension" json:"override-archive-extension" mapstructure:"override-archive-extension"`
+	PublishBaseURL           string            `yaml:"publish-base-url" json:"publish-base-url" mapstructure:"publish-base-url"`
+	OverrideArchiveExtension string            `yaml:"override-archive-extension" json:"override-archive-extension" mapstructure:"override-archive-extension"`
+	CompressorCommands       map[string]string `yaml:"compressor-commands" json:"compressor-commands" mapstructure:"compressor-commands"`
 
 	// unbound options
-	// (none)
+	compressorCommandsJSON string
 }
 
 func DefaultPackage() Package {
@@ -45,9 +46,6 @@ func (o *Package) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
 	if err := viper.BindPFlag("package.override-archive-extension", flags.Lookup("archive-extension")); err != nil {
 		return err
 	}
-
-	// set default values for non-bound struct items
-	// (none)
 
 	return nil
 }

--- a/internal/tarutil/populate.go
+++ b/internal/tarutil/populate.go
@@ -2,7 +2,12 @@ package tarutil
 
 // PopulateWithPaths creates a compressed tar from the given paths.
 func PopulateWithPaths(tarPath string, filePaths ...string) error {
-	w, err := NewWriter(tarPath)
+	return PopulateWithPathsAndCompressors(tarPath, nil, filePaths...)
+}
+
+// PopulateWithPathsAndCompressors creates a compressed tar from the given paths using custom compressor commands.
+func PopulateWithPathsAndCompressors(tarPath string, compressorCommands map[string]string, filePaths ...string) error {
+	w, err := NewWriterWithCompressors(tarPath, compressorCommands)
 	if err != nil {
 		return err
 	}

--- a/pkg/process/package.go
+++ b/pkg/process/package.go
@@ -8,11 +8,11 @@ import (
 	grypeDBLegacyDistribution "github.com/anchore/grype/grype/db/v5/distribution"
 )
 
-func Package(dbDir, publishBaseURL, overrideArchiveExtension string) error {
+func Package(dbDir, publishBaseURL, overrideArchiveExtension string, compressorCommands map[string]string) error {
 	// check if metadata file exists, if so, then this
 	if _, err := os.Stat(filepath.Join(dbDir, grypeDBLegacyDistribution.MetadataFileName)); os.IsNotExist(err) {
 		// TODO: detect from disk which version of the DB is present
-		return v6process.CreateArchive(dbDir, overrideArchiveExtension)
+		return v6process.CreateArchive(dbDir, overrideArchiveExtension, compressorCommands)
 	}
-	return packageLegacyDB(dbDir, publishBaseURL, overrideArchiveExtension)
+	return packageLegacyDB(dbDir, publishBaseURL, overrideArchiveExtension, compressorCommands)
 }

--- a/pkg/process/package_legacy.go
+++ b/pkg/process/package_legacy.go
@@ -22,7 +22,7 @@ import (
 // listingFiles is a set of files that should not be included in the archive
 var listingFiles = strset.New("listing.json", "latest.json", "history.json")
 
-func packageLegacyDB(dbDir, publishBaseURL, overrideArchiveExtension string) error { //nolint:funlen
+func packageLegacyDB(dbDir, publishBaseURL, overrideArchiveExtension string, compressorCommands map[string]string) error { //nolint:funlen
 	log.WithFields("from", dbDir, "url", publishBaseURL, "extension-override", overrideArchiveExtension).Info("packaging database")
 
 	fs := afero.NewOsFs()
@@ -88,7 +88,7 @@ func packageLegacyDB(dbDir, publishBaseURL, overrideArchiveExtension string) err
 	)
 	tarPath := path.Join(dbDir, tarName)
 
-	if err := populateLegacyTar(tarPath); err != nil {
+	if err := populateLegacyTar(tarPath, compressorCommands); err != nil {
 		return err
 	}
 
@@ -110,7 +110,7 @@ func packageLegacyDB(dbDir, publishBaseURL, overrideArchiveExtension string) err
 	return nil
 }
 
-func populateLegacyTar(tarPath string) error {
+func populateLegacyTar(tarPath string, compressorCommands map[string]string) error {
 	originalDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("unable to get CWD: %w", err)
@@ -142,7 +142,7 @@ func populateLegacyTar(tarPath string) error {
 		}
 	}
 
-	if err = tarutil.PopulateWithPaths(tarName, files...); err != nil {
+	if err = tarutil.PopulateWithPathsAndCompressors(tarName, compressorCommands, files...); err != nil {
 		return fmt.Errorf("unable to create db archive: %w", err)
 	}
 

--- a/pkg/process/v6/archive.go
+++ b/pkg/process/v6/archive.go
@@ -16,7 +16,7 @@ import (
 	v6Distribution "github.com/anchore/grype/grype/db/v6/distribution"
 )
 
-func CreateArchive(dbDir, overrideArchiveExtension string) error {
+func CreateArchive(dbDir, overrideArchiveExtension string, compressorCommands map[string]string) error {
 	extension, err := resolveExtension(overrideArchiveExtension)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func CreateArchive(dbDir, overrideArchiveExtension string) error {
 		files = append(files, v6.ImportMetadataFileName)
 	}
 
-	if err := populateTar(dbDir, tarName, files...); err != nil {
+	if err := populateTar(dbDir, tarName, compressorCommands, files...); err != nil {
 		return err
 	}
 
@@ -112,7 +112,7 @@ func resolveExtension(overrideArchiveExtension string) (string, error) {
 	return extension, nil
 }
 
-func populateTar(dbDir, tarName string, files ...string) error {
+func populateTar(dbDir, tarName string, compressorCommands map[string]string, files ...string) error {
 	originalDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("unable to get CWD: %w", err)
@@ -137,7 +137,7 @@ func populateTar(dbDir, tarName string, files ...string) error {
 		}
 	}
 
-	if err = tarutil.PopulateWithPaths(tarName, files...); err != nil {
+	if err = tarutil.PopulateWithPathsAndCompressors(tarName, compressorCommands, files...); err != nil {
 		return fmt.Errorf("unable to create db archive: %w", err)
 	}
 


### PR DESCRIPTION
Allows for adding custom commands to compress the tar that is generated by grype-db.

```yaml
# .grype-db.yaml
package:
  compressor-commands:
    gz: "gzip -c -9"
```

This allows us to try out more CLI tools for compression (such as pigz or zopfli)