### PR TITLE
Add fix available date to GHSA entries

### DIFF
--- a/pkg/process/v6/transformers/github/test-fixtures/GHSA-2wgc-48g2-cj5w.json
+++ b/pkg/process/v6/transformers/github/test-fixtures/GHSA-2wgc-48g2-cj5w.json
@@ -20,7 +20,11 @@
         "identifier": "4.2.0",
         "ecosystem": "python",
         "namespace": "github:python",
-        "range": "< 4.2.0"
+        "range": "< 4.2.0",
+        "available": {
+          "date": "2024-01-30T15:00:00Z",
+          "kind": "advisory"
+        }
       }
     ],
     "Summary": "vantage6 has insecure SSH configuration for node and server containers",

--- a/pkg/process/v6/transformers/github/test-fixtures/multiple-fixed-in-names.json
+++ b/pkg/process/v6/transformers/github/test-fixtures/multiple-fixed-in-names.json
@@ -10,14 +10,22 @@
         "identifier": "4.3.12",
         "name": "Plone",
         "namespace": "github:python",
-        "range": ">= 4.0 < 4.3.12"
+        "range": ">= 4.0 < 4.3.12",
+        "available": {
+          "date": "2017-05-20T10:30:45Z",
+          "kind": "release"
+        }
       },
       {
         "ecosystem": "python",
         "identifier": "5.1b1",
         "name": "Plone",
         "namespace": "github:python",
-        "range": ">= 5.1a1 < 5.1b1"
+        "range": ">= 5.1a1 < 5.1b1",
+        "available": {
+          "date": "2017-06-15T14:22:33Z",
+          "kind": "commit"
+        }
       },
       {
         "ecosystem": "python",

--- a/pkg/process/v6/transformers/github/transform.go
+++ b/pkg/process/v6/transformers/github/transform.go
@@ -145,9 +145,35 @@ func getFix(fixedInEntry unmarshal.GithubFixedIn) *grypeDB.Fix {
 		fixState = grypeDB.FixedStatus
 	}
 
+	var detail *grypeDB.FixDetail
+	availability := getFixAvailability(fixedInEntry)
+	if availability != nil {
+		detail = &grypeDB.FixDetail{
+			Available: availability,
+		}
+	}
+
 	return &grypeDB.Fix{
 		Version: fixedInVersion,
 		State:   fixState,
+		Detail:  detail,
+	}
+}
+
+func getFixAvailability(fixedInEntry unmarshal.GithubFixedIn) *grypeDB.FixAvailability {
+	if fixedInEntry.Available.Date == "" {
+		return nil
+	}
+
+	t := internal.ParseTime(fixedInEntry.Available.Date)
+	if t == nil {
+		log.WithFields("date", fixedInEntry.Available.Date).Warn("unable to parse fix availability date")
+		return nil
+	}
+
+	return &grypeDB.FixAvailability{
+		Date: t,
+		Kind: fixedInEntry.Available.Kind,
 	}
 }
 

--- a/pkg/process/v6/transformers/os/test-fixtures/alpine-3.9.json
+++ b/pkg/process/v6/transformers/os/test-fixtures/alpine-3.9.json
@@ -8,7 +8,11 @@
           "Name": "xen",
           "NamespaceName": "alpine:3.9",
           "Version": "4.11.1-r0",
-          "VersionFormat": "apk"
+          "VersionFormat": "apk",
+          "Available": {
+            "Date": "2018-12-01T09:15:30Z",
+            "Kind": "package"
+          }
         }
       ],
       "Link": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19967",

--- a/pkg/process/v6/transformers/os/test-fixtures/rhel-8.json
+++ b/pkg/process/v6/transformers/os/test-fixtures/rhel-8.json
@@ -29,7 +29,11 @@
             "NoAdvisory": false
           },
           "Version": "0:68.6.1-1.el8_1",
-          "VersionFormat": "rpm"
+          "VersionFormat": "rpm",
+          "Available": {
+            "Date": "2020-04-08T14:30:15Z",
+            "Kind": "advisory"
+          }
         },
         {
           "Name": "thunderbird",

--- a/pkg/provider/unmarshal/github_advisory.go
+++ b/pkg/provider/unmarshal/github_advisory.go
@@ -48,4 +48,8 @@ type GithubFixedIn struct {
 	Name       string `json:"name"`
 	Namespace  string `json:"namespace"`
 	Range      string `json:"range"`
+	Available  struct {
+		Date string `json:"date,omitempty"`
+		Kind string `json:"kind,omitempty"`
+	} `json:"available,omitempty"`
 }


### PR DESCRIPTION
Pairs with the changes in https://github.com/anchore/vunnel/pull/852 (also adds more tests around the OS transform changes introduced in https://github.com/anchore/grype-db/pull/629)