### PR TITLE
fix: recognize jvm versions at DB build time

### DIFF
--- a/pkg/process/v6/transformers/nvd/test-fixtures/jvm-packages.json
+++ b/pkg/process/v6/transformers/nvd/test-fixtures/jvm-packages.json
@@ -1,0 +1,99 @@
+{
+  "cve": {
+    "id": "CVE-2023-JVM-TEST",
+    "sourceIdentifier": "cve@mitre.org",
+    "published": "2024-01-17T00:15:51.677",
+    "lastModified": "2024-01-23T16:32:52.103",
+    "vulnStatus": "Analyzed",
+    "descriptions": [
+      {
+        "lang": "en",
+        "value": "Test vulnerability affecting JVM packages to demonstrate version format detection."
+      }
+    ],
+    "metrics": {
+      "cvssMetricV31": [
+        {
+          "source": "nvd@nist.gov",
+          "type": "Primary",
+          "cvssData": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "baseScore": 6.1,
+            "baseSeverity": "MEDIUM",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "REQUIRED",
+            "scope": "CHANGED",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "availabilityImpact": "NONE"
+          },
+          "exploitabilityScore": 2.8,
+          "impactScore": 2.7
+        }
+      ]
+    },
+    "weaknesses": [
+      {
+        "source": "nvd@nist.gov",
+        "type": "Primary",
+        "description": [
+          {
+            "lang": "en",
+            "value": "CWE-79"
+          }
+        ]
+      }
+    ],
+    "configurations": [
+      {
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:oracle:jdk:8u401:*:*:*:*:*:*:*",
+                "matchCriteriaId": "oracle-jdk-8u401"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:oracle:jdk:11.0.22:*:*:*:*:*:*:*",
+                "matchCriteriaId": "oracle-jdk-11.0.22"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:eclipse:openjdk:17.0.10:*:*:*:*:*:*:*",
+                "matchCriteriaId": "eclipse-openjdk-17.0.10"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:azul:zulu:21.0.2:*:*:*:*:*:*:*",
+                "matchCriteriaId": "azul-zulu-21.0.2"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:adoptium:java:17.0.10:*:*:*:*:*:*:*",
+                "matchCriteriaId": "adoptium-java-17.0.10"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "references": [
+      {
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-JVM-TEST",
+        "source": "nvd@nist.gov"
+      },
+      {
+        "url": "https://www.oracle.com/security-alerts/cpujan2024.html",
+        "source": "nvd@nist.gov",
+        "tags": ["Patch", "Vendor Advisory"]
+      }
+    ]
+  }
+}

--- a/pkg/process/v6/transformers/nvd/transform.go
+++ b/pkg/process/v6/transformers/nvd/transform.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anchore/grype-db/pkg/provider/unmarshal"
 	"github.com/anchore/grype-db/pkg/provider/unmarshal/nvd"
 	grypeDB "github.com/anchore/grype/grype/db/v6"
+	"github.com/anchore/grype/grype/pkg"
 	"github.com/anchore/syft/syft/cpe"
 )
 
@@ -26,6 +27,13 @@ func defaultConfig() Config {
 		CPEParts:            strset.New("a", "h", "o"),
 		InferNVDFixVersions: true,
 	}
+}
+
+func getVersionFormat(cpeProduct string) string {
+	if pkg.HasJvmPackageName(cpeProduct) {
+		return "jvm"
+	}
+	return ""
 }
 
 func Transformer(cfg Config) data.NVDTransformerV2 {
@@ -194,7 +202,7 @@ func getRanges(cfg Config, c cpe.Attributes, ras []affectedCPERange) []grypeDB.A
 func getRange(cfg Config, c cpe.Attributes, ra affectedCPERange) *grypeDB.AffectedRange {
 	return &grypeDB.AffectedRange{
 		Version: grypeDB.AffectedVersion{
-			Type:       "", // we explicitly do not know what the versioning scheme is
+			Type:       getVersionFormat(c.Product),
 			Constraint: ra.String(),
 		},
 		Fix: getFix(cfg, c, ra),

--- a/pkg/process/v6/transformers/nvd/transform_test.go
+++ b/pkg/process/v6/transformers/nvd/transform_test.go
@@ -1434,6 +1434,132 @@ func TestTransform(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "JVM packages version format detection",
+			fixture:  "test-fixtures/jvm-packages.json",
+			provider: "nvd",
+			config:   defaultConfig(),
+			want: []transformers.RelatedEntries{
+				{
+					VulnerabilityHandle: &grypeDB.VulnerabilityHandle{
+						Name:          "CVE-2023-JVM-TEST",
+						ProviderID:    "nvd",
+						Provider:      expectedProvider("nvd"),
+						ModifiedDate:  timeRef(time.Date(2024, 1, 23, 16, 32, 52, 103000000, time.UTC)),
+						PublishedDate: timeRef(time.Date(2024, 1, 17, 0, 15, 51, 677000000, time.UTC)),
+						Status:        grypeDB.VulnerabilityActive,
+						BlobValue: &grypeDB.VulnerabilityBlob{
+							ID:          "CVE-2023-JVM-TEST",
+							Assigners:   []string{"cve@mitre.org"},
+							Description: "Test vulnerability affecting JVM packages to demonstrate version format detection.",
+							References: []grypeDB.Reference{
+								{
+									URL: "https://nvd.nist.gov/vuln/detail/CVE-2023-JVM-TEST",
+								},
+								{
+									URL: "https://nvd.nist.gov/vuln/detail/CVE-2023-JVM-TEST",
+								},
+								{
+									URL:  "https://www.oracle.com/security-alerts/cpujan2024.html",
+									Tags: []string{"patch", "vendor-advisory"},
+								},
+							},
+							Severities: []grypeDB.Severity{
+								{
+									Scheme: grypeDB.SeveritySchemeCVSS,
+									Value: grypeDB.CVSSSeverity{
+										Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+										Version: "3.1",
+									},
+									Source: "nvd@nist.gov",
+									Rank:   1,
+								},
+							},
+						},
+					},
+					Related: affectedPkgSlice(
+						grypeDB.AffectedCPEHandle{
+							BlobValue: &grypeDB.AffectedPackageBlob{
+								CVEs: []string{"CVE-2023-JVM-TEST"},
+								Ranges: []grypeDB.AffectedRange{
+									{
+										Version: grypeDB.AffectedVersion{
+											Type:       "jvm",
+											Constraint: "= 17.0.10",
+										},
+									},
+								},
+							},
+							CPE: &grypeDB.Cpe{
+								Part:    "a",
+								Vendor:  "adoptium",
+								Product: "java",
+							},
+						},
+						grypeDB.AffectedCPEHandle{
+							BlobValue: &grypeDB.AffectedPackageBlob{
+								CVEs: []string{"CVE-2023-JVM-TEST"},
+								Ranges: []grypeDB.AffectedRange{
+									{
+										Version: grypeDB.AffectedVersion{
+											Type:       "jvm",
+											Constraint: "= 21.0.2",
+										},
+									},
+								},
+							},
+							CPE: &grypeDB.Cpe{
+								Part:    "a",
+								Vendor:  "azul",
+								Product: "zulu",
+							},
+						},
+						grypeDB.AffectedCPEHandle{
+							BlobValue: &grypeDB.AffectedPackageBlob{
+								CVEs: []string{"CVE-2023-JVM-TEST"},
+								Ranges: []grypeDB.AffectedRange{
+									{
+										Version: grypeDB.AffectedVersion{
+											Type:       "jvm",
+											Constraint: "= 17.0.10",
+										},
+									},
+								},
+							},
+							CPE: &grypeDB.Cpe{
+								Part:    "a",
+								Vendor:  "eclipse",
+								Product: "openjdk",
+							},
+						},
+						grypeDB.AffectedCPEHandle{
+							BlobValue: &grypeDB.AffectedPackageBlob{
+								CVEs: []string{"CVE-2023-JVM-TEST"},
+								Ranges: []grypeDB.AffectedRange{
+									{
+										Version: grypeDB.AffectedVersion{
+											Type:       "jvm",
+											Constraint: "= 11.0.22",
+										},
+									},
+									{
+										Version: grypeDB.AffectedVersion{
+											Type:       "jvm",
+											Constraint: "= 8u401",
+										},
+									},
+								},
+							},
+							CPE: &grypeDB.Cpe{
+								Part:    "a",
+								Vendor:  "oracle",
+								Product: "jdk",
+							},
+						},
+					),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When processing CPEs in the NVD provider, if a CPE seems to be for a JVM based on its package namme, set its version type to be "jvm" so that grype knows at match time to use special comparison logic for JVM versions.