### PR TITLE
chore: publish db 2 hours later

### DIFF
--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -16,7 +16,7 @@ on:
 
   # run 4 AM (UTC) daily
   schedule:
-    - cron:  '0 4 * * *'
+    - cron:  '0 6 * * *'
 
 env:
   CGO_ENABLED: "0"


### PR DESCRIPTION
There have been several DB publishing failures apparently caused by the publish job attempting to run before the sync job finished. Therefore, make the publish job start later relative to the sync job.

https://github.com/anchore/grype-db/actions/runs/17285433313/attempts/1 is the most recent example.

From the publisher job:

```
Thu, 28 Aug 2025 04:04:50 GMT
Error response from registry: failed to resolve 25-08-28: ghcr.io/anchore/grype-db/data:25-08-28: not found
```

From the [data sync job](https://github.com/anchore/grype-db/actions/runs/17283083731/job/49063529022#step:6:144):

```
Thu, 28 Aug 2025 05:03:54 GMT
Pushed [registry] ghcr.io/anchore/grype-db/data:25-08-28
```

Note that the publisher job tried to pull the data almost 1 hour before it was available. To give some more headroom, move this job 2 hours into the future, so that it will generally run at least an hour after the data sync finishes. (The data sync is pretty variable since it makes 1000s of network requests with retries, so if some API is having a bad day, it can take quite a bit longer.)