### PR TITLE
Validate only the results.db file

### DIFF
--- a/pkg/provider/entry/sqlite.go
+++ b/pkg/provider/entry/sqlite.go
@@ -39,7 +39,8 @@ type errorOpener struct {
 func sqliteEntryCount(resultPaths []string) (int64, error) {
 	var dbPath string
 	for _, p := range resultPaths {
-		if strings.HasSuffix(p, ".db") {
+		// we should only be validating against a single results DB, not any DB in the output
+		if strings.HasSuffix(p, "results.db") {
 			dbPath = p
 			break
 		}


### PR DESCRIPTION
Today the check for which DB to validate in a vunnel cache is too broad, not allowing multiple databases from being persisted. This tightens the DB validated to the single results.db file.