### PR TITLE
Add GRYPE_DB_EXECUTABLE_PATH support to bypass Go build requirement

### DIFF
--- a/manager/src/grype_db_manager/grypedb.py
+++ b/manager/src/grype_db_manager/grypedb.py
@@ -605,7 +605,23 @@ def _check_executable_path_override() -> str | None:
     return None
 
 
-def _install_grype_db(input_version: str, bin_dir: str, clone_dir: str) -> str:  # noqa: PLR0912
+def _install_grype_db(input_version: str, bin_dir: str, clone_dir: str) -> str:  # noqa: PLR0912, C901
+    """
+    Install grype-db CLI from a specified version.
+
+    This can be a specific semver version (e.g. v0.7.0), "latest", a GitHub repo (e.g. user/repo or user/repo@branch),
+    or a local file path (e.g. file:///path/to/grype-db).
+    If an environment variable GRYPE_DB_EXECUTABLE_PATH is set and points to an executable, that binary will be used instead.
+
+    Args:
+        input_version (str): The version or source to install from.
+        bin_dir (str): The directory to install the binary into.
+        clone_dir (str): The directory to clone the repository into if needed.
+
+    Returns:
+        str | None: The path to the installed binary, or None if no installation was performed.
+
+    """
     os.makedirs(bin_dir, exist_ok=True)
 
     # Check for explicit grype-db binary override (opt-in only)

--- a/manager/src/grype_db_manager/grypedb.py
+++ b/manager/src/grype_db_manager/grypedb.py
@@ -595,15 +595,22 @@ def print_annotation(s: str, italic: bool = True, grey: bool = True) -> None:
     sys.stderr.write(s + "\n")
 
 
-def _install_grype_db(input_version: str, bin_dir: str, clone_dir: str) -> str:  # noqa: PLR0912
-    os.makedirs(bin_dir, exist_ok=True)
-
-    # Check for explicit grype-db binary override (opt-in only)
+def _check_executable_path_override() -> str | None:
+    """Check for existing grype-db binary via GRYPE_DB_EXECUTABLE_PATH environment variable."""
     if grype_db_path := os.getenv("GRYPE_DB_EXECUTABLE_PATH"):
         if shutil.which(grype_db_path):
             logging.info(f"Using grype-db from GRYPE_DB_EXECUTABLE_PATH: {grype_db_path}")
             return grype_db_path
         logging.warning(f"GRYPE_DB_EXECUTABLE_PATH points to non-executable: {grype_db_path}")
+    return None
+
+
+def _install_grype_db(input_version: str, bin_dir: str, clone_dir: str) -> str:  # noqa: PLR0912
+    os.makedirs(bin_dir, exist_ok=True)
+
+    # Check for explicit grype-db binary override (opt-in only)
+    if existing_binary := _check_executable_path_override():
+        return existing_binary
 
     version = input_version
     is_semver = re.match(r"v\d+\.\d+\.\d+", input_version)

--- a/manager/src/grype_db_manager/grypedb.py
+++ b/manager/src/grype_db_manager/grypedb.py
@@ -598,6 +598,13 @@ def print_annotation(s: str, italic: bool = True, grey: bool = True) -> None:
 def _install_grype_db(input_version: str, bin_dir: str, clone_dir: str) -> str:  # noqa: PLR0912
     os.makedirs(bin_dir, exist_ok=True)
 
+    # Check for explicit grype-db binary override (opt-in only)
+    if grype_db_path := os.getenv("GRYPE_DB_EXECUTABLE_PATH"):
+        if shutil.which(grype_db_path):
+            logging.info(f"Using grype-db from GRYPE_DB_EXECUTABLE_PATH: {grype_db_path}")
+            return grype_db_path
+        logging.warning(f"GRYPE_DB_EXECUTABLE_PATH points to non-executable: {grype_db_path}")
+
     version = input_version
     is_semver = re.match(r"v\d+\.\d+\.\d+", input_version)
     repo_user_and_name = "anchore/grype-db"


### PR DESCRIPTION
## Summary

Add opt-in environment variable `GRYPE_DB_EXECUTABLE_PATH` to allow using pre-built grype-db binaries instead of building from source. This enables running grype-db-manager in distroless containers or environments without Go toolchain installed.

## Changes

- Added `GRYPE_DB_EXECUTABLE_PATH` environment variable support
- Uses cross-platform `shutil.which()` for executable validation
- Logs warning and falls back to source build if path is invalid
- No behavior change for existing users (opt-in only)
- Comprehensive test coverage for all scenarios

## Use Case

Useful for CI environments where grype-db binary is already available, eliminating the need for Go toolchain in container images. This **does** include the same checks, but skips the build / pull if the executable exists.

## Testing

```bash
# Run new tests
uv run pytest manager/tests/unit/test_grypedb.py::TestGrypeDB::test_install_grype_db_with_executable_path -v

# All manager tests pass
uv run pytest manager/tests/unit/test_grypedb.py
```