### PR TITLE
chore: use latest released grype-db to publish DB

### DIFF
--- a/config/grype-db-manager/include.d/grype-db-local-build-r2.yaml
+++ b/config/grype-db-manager/include.d/grype-db-local-build-r2.yaml
@@ -2,7 +2,7 @@
 
 # use the current repo at the current commit as the source of truth for the grype-db build source.
 # note: assume this will be invoked from the root of the repo
-version: file://.
+version: latest
 
 # grype-db application configuration to use.
 # note: assume this will be invoked from the root of the repo


### PR DESCRIPTION
Otherwise, there's a concern that unreleased changes in the grype-db repo will reference models in unreleased changes in grype. Basically, this change makes it so that merging into grype-db won't affect the published database until grype-db is released. This behavior is probably what everyone expected anyway, and is how vunnel has always behaved.