### PR TITLE
Switch to using runs-on

### DIFF
--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   discover-providers:
     name: "Discover vulnerability providers"
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=small
     if: github.repository == 'anchore/grype-db' # only run for main repo
     permissions:
       contents: read
@@ -47,7 +47,7 @@ jobs:
   update-provider:
     name: "Update provider"
     needs: discover-providers
-    runs-on: ubuntu-22.04-4core-16gb
+    runs-on: runs-on=${{ github.run_id }}/runner=large
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:
       contents: read
@@ -102,7 +102,7 @@ jobs:
 
   aggregate-cache:
     name: "Aggregate provider cache"
-    runs-on: ubuntu-22.04-4core-16gb
+    runs-on: runs-on=${{ github.run_id }}/runner=large
     if: ${{ always() }}
     needs:
       - update-provider

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -30,7 +30,7 @@ jobs:
     # b) if not using workflow_dispatch the default values are empty, which means we want these to effectively evaluate to true (so only check the negative case)
     if: ${{ github.event.inputs.publish-databases != 'false' && github.repository == 'anchore/grype-db' }} # only run for main repo
     name: "Pull vulnerability data"
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=small
     outputs:
       schema-versions: ${{ steps.read-schema-versions.outputs.schema-versions }}
       pull-date: ${{ steps.timestamp.outputs.date }}
@@ -57,7 +57,7 @@ jobs:
     if: ${{ github.event.inputs.publish-databases != 'false' }}
     name: "Generate and publish DBs"
     needs: discover-schema-versions
-    runs-on: ubuntu-22.04-4core-16gb
+    runs-on: runs-on=${{ github.run_id }}/runner=large
     strategy:
       matrix:
         schema-version: ${{fromJson(needs.discover-schema-versions.outputs.schema-versions)}}
@@ -122,7 +122,7 @@ jobs:
 
     name: "Publish listing file"
     needs: generate-and-publish-dbs
-    runs-on: ubuntu-22.04-4core-16gb
+    runs-on: runs-on=${{ github.run_id }}/runner=large
     permissions:
       contents: read
     steps:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -21,7 +21,7 @@ jobs:
     name: "Static analysis"
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=small
     steps:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
@@ -39,7 +39,7 @@ jobs:
     name: "Unit tests (Go)"
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=small
     steps:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
@@ -59,7 +59,7 @@ jobs:
     name: "Unit tests (Python)"
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=small
     steps:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
@@ -79,7 +79,7 @@ jobs:
     name: "Build snapshot artifacts"
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=small
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
@@ -112,7 +112,7 @@ jobs:
     name: "Discover supported schema versions"
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=small
     outputs:
       schema-versions: ${{ steps.read-schema-versions.outputs.schema-versions }}
     steps:
@@ -131,7 +131,7 @@ jobs:
   Acceptance-Test:
     name: "Acceptance tests"
     needs: Discover-Schema-Versions
-    runs-on: ubuntu-22.04-4core-16gb
+    runs-on: runs-on=${{ github.run_id }}/runner=large
     strategy:
       matrix:
         schema-version: ${{fromJson(needs.Discover-Schema-Versions.outputs.schema-versions)}}
@@ -171,7 +171,7 @@ jobs:
     permissions:
       contents: read
     needs: [Build-Snapshot-Artifacts]
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=small
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
@@ -202,7 +202,7 @@ jobs:
     name: "CLI tests (Python)"
     permissions:
       contents: read
-    runs-on: ubuntu-22.04-4core-16gb
+    runs-on: runs-on=${{ github.run_id }}/runner=large
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:


### PR DESCRIPTION
This bumps the large runners to using [32 GB](https://github.com/anchore/workflows/blob/main/.github/runs-on.yml) to prevent memory issues when aggregating cache (fix [inbound](https://github.com/anchore/grype-db/pull/718))