### PR TITLE
feat: enable AlmaLinux provider

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -12,6 +12,7 @@ provider:
   configs:
     - name: nvd
     - name: alpine
+    - name: alma
     - name: amazon
     - name: bitnami
     - name: chainguard


### PR DESCRIPTION
This will allow Grype to consider AlmaLinux advisories in addition to RHEL advisories when scanning AlmaLinux images.

## TODO

- [x] merge https://github.com/anchore/vunnel/pull/886 and release vunnel