### PR TITLE
feat(manager/src/grype_db_manager/grypedb.py): do not require shell environment for subprocess

### DIFF
--- a/manager/src/grype_db_manager/grypedb.py
+++ b/manager/src/grype_db_manager/grypedb.py
@@ -562,7 +562,7 @@ class GrypeDB:
         )
 
     def run(self, *args, provider_root_dir: str, config: str) -> int:
-        cmd = " ".join([self.bin_path, *args]) if self.bin_path else " ".join(["grype-db", *args])
+        cmd = [self.bin_path, *args] if self.bin_path else ["grype-db", *args]
         level = logging.getLevelName(logging.getLogger().getEffectiveLevel())
         if level == "TRACE":
             # trace is not supported in grype-db yet
@@ -578,7 +578,7 @@ class GrypeDB:
             GRYPE_DB_LOG_LEVEL=level,
         )
 
-        ret = subprocess.check_call(cmd, env=env, shell=True)  # noqa: S602
+        ret = subprocess.check_call(cmd, env=env)  # noqa: S603
 
         print_annotation("[end grype-db output]")
         return ret

--- a/manager/tests/unit/test_grypedb.py
+++ b/manager/tests/unit/test_grypedb.py
@@ -175,16 +175,16 @@ class TestGrypeDB:
 
         # make certain the mock was called with at least
         #   env = {GRYPE_DB_VUNNEL_ROOT: "provider_root_path", GRYPE_DB_CONFIG: "config_path", GRYPE_DB_LOG_LEVEL: "DEBUG"}
-        #   shell = True
-        #   cmd= ".../bin/grype-db-v0.19.0 version"
+        #   shell = False (or not set, which defaults to False)
+        #   cmd = [".../bin/grype-db-v0.19.0", "version"]
 
         mock_check_call.assert_called_once()
         args, kwargs = mock_check_call.call_args
-        assert kwargs["shell"] is True
+        assert "shell" not in kwargs or kwargs["shell"] is False
         assert kwargs["env"]["GRYPE_DB_VUNNEL_ROOT"] == "provider_root_path"
         assert kwargs["env"]["GRYPE_DB_CONFIG"] == "config_path"
         assert kwargs["env"]["GRYPE_DB_LOG_LEVEL"] == "DEBUG"
-        assert args[0] == f"{bin_path} version"
+        assert args[0] == [bin_path, "version"]
 
     def test_check_executable_path_override_valid_path(self, tmp_path: pathlib.Path, mocker):
         """Test _check_executable_path_override returns path when GRYPE_DB_EXECUTABLE_PATH is valid."""


### PR DESCRIPTION
This change is to allow grype-db-manager to run without invoking subprocess with `shell=True`. Using `shell=True` is useful for things like command piping, builtins, etc.  From what I can tell this is just being used to execute other CLIs, so it should be safe. 

If there are more considerations that I am missing please let me know! 