### PR TITLE
Give data sync more time to prevent failures

### DIFF
--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -3,9 +3,9 @@ on:
   # allow for kicking off data syncs manually
   workflow_dispatch:
 
-  # run 1 AM (UTC) daily
+  # run midnight (UTC) daily
   schedule:
-    - cron:  '0 1 * * *'
+    - cron:  '0 0 * * *'
 
 env:
   CGO_ENABLED: "0"

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -14,9 +14,9 @@ on:
         required: true
         default: true
 
-  # run 4 AM (UTC) daily
+  # run 7 AM (UTC) daily
   schedule:
-    - cron:  '0 6 * * *'
+    - cron:  '0 7 * * *'
 
 env:
   CGO_ENABLED: "0"


### PR DESCRIPTION
Sometimes the ubuntu provider needs almost 6 hours to complete, this gives enough room to run the provider and upload the results.