### PR TITLE
feat: handle ROOTIO_UNAFFECTED markers in OS transformer

### DIFF
--- a/pkg/process/v6/transformers/os/test-fixtures/rootio-alpine-no-fix.json
+++ b/pkg/process/v6/transformers/os/test-fixtures/rootio-alpine-no-fix.json
@@ -1,0 +1,30 @@
+{
+  "Vulnerability": {
+    "CVSS": [],
+    "Description": "Root.io vulnerability record with no fix available",
+    "FixedIn": [
+      {
+        "Name": "unpatched-package",
+        "NamespaceName": "rootio:distro:alpine:3.17",
+        "VendorAdvisory": {
+          "AdvisorySummary": [],
+          "NoAdvisory": true
+        },
+        "Version": "",
+        "VersionFormat": "apk"
+      }
+    ],
+    "Link": "",
+    "Metadata": {
+      "CVE": [
+        {
+          "Name": "CVE-2023-9999",
+          "Link": ""
+        }
+      ]
+    },
+    "Name": "CVE-2023-9999",
+    "NamespaceName": "rootio:distro:alpine:3.17",
+    "Severity": "Medium"
+  }
+}

--- a/pkg/process/v6/transformers/os/test-fixtures/rootio-alpine-r007-pattern.json
+++ b/pkg/process/v6/transformers/os/test-fixtures/rootio-alpine-r007-pattern.json
@@ -1,0 +1,30 @@
+{
+  "Vulnerability": {
+    "CVSS": [],
+    "Description": "Root.io vulnerability record with Alpine -rXX007X pattern",
+    "FixedIn": [
+      {
+        "Name": "libssl3",
+        "NamespaceName": "rootio:distro:alpine:3.21",
+        "VendorAdvisory": {
+          "AdvisorySummary": [],
+          "NoAdvisory": false
+        },
+        "Version": "3.0.8-r00071",
+        "VersionFormat": "apk"
+      }
+    ],
+    "Link": "",
+    "Metadata": {
+      "CVE": [
+        {
+          "Name": "CVE-2024-1234",
+          "Link": ""
+        }
+      ]
+    },
+    "Name": "CVE-2024-1234",
+    "NamespaceName": "rootio:distro:alpine:3.21",
+    "Severity": "High"
+  }
+}

--- a/pkg/process/v6/transformers/os/test-fixtures/rootio-alpine-unaffected.json
+++ b/pkg/process/v6/transformers/os/test-fixtures/rootio-alpine-unaffected.json
@@ -1,0 +1,30 @@
+{
+  "Vulnerability": {
+    "CVSS": [],
+    "Description": "Root.io vulnerability record indicating test-package is fixed",
+    "FixedIn": [
+      {
+        "Name": "test-package",
+        "NamespaceName": "rootio:distro:alpine:3.17",
+        "VendorAdvisory": {
+          "AdvisorySummary": [],
+          "NoAdvisory": false
+        },
+        "Version": "3.0.8-r4",
+        "VersionFormat": "apk"
+      }
+    ],
+    "Link": "",
+    "Metadata": {
+      "CVE": [
+        {
+          "Name": "CVE-2023-1234",
+          "Link": ""
+        }
+      ]
+    },
+    "Name": "CVE-2023-1234",
+    "NamespaceName": "rootio:distro:alpine:3.17",
+    "Severity": "Medium"
+  }
+}


### PR DESCRIPTION
  - Recognize ROOTIO_UNAFFECTED version markers from vunnel
  - Set NotAffectedFixStatus for Root.io unaffected vulnerabilities
  - Handle Root.io namespace format (rootio:distro:alpine:3.17)
  - Add Root.io reference URL and tags for tracking
  - Include unit tests for new functionality

  This enables grype-db to properly process Root.io security patches
  and prevent false positive vulnerability matches.

  Signed-off-by: Chai Tadmor <chai.tadmor@root.io>