### PR TITLE
fix: deduplicate references in NVD transformer

### DIFF
--- a/pkg/process/v6/transformers/nvd/transform.go
+++ b/pkg/process/v6/transformers/nvd/transform.go
@@ -2,6 +2,7 @@ package nvd
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/scylladb/go-set/strset"
@@ -347,12 +348,60 @@ func getReferences(vuln unmarshal.NVDVulnerability) []grypeDB.Reference {
 		if reference.URL == "" {
 			continue
 		}
+		tags := grypeDB.NormalizeReferenceTags(reference.Tags)
+		sort.Strings(tags)
 		// TODO there is other info we could be capturing too (source)
 		references = append(references, grypeDB.Reference{
 			URL:  reference.URL,
-			Tags: grypeDB.NormalizeReferenceTags(reference.Tags),
+			Tags: tags,
 		})
 	}
 
-	return references
+	return deduplicateReferences(references)
+}
+
+// deduplicateReferences removes duplicate references, where two references are considered
+// identical if they have the same URL and their normalized, sorted tags are equal
+func deduplicateReferences(references []grypeDB.Reference) []grypeDB.Reference {
+	var result []grypeDB.Reference
+	seenBefore := make(map[string][]grypeDB.Reference)
+	for _, ref := range references {
+		if _, anySeenRefs := seenBefore[ref.URL]; !anySeenRefs {
+			seenBefore[ref.URL] = []grypeDB.Reference{ref}
+			result = append(result, ref)
+			continue
+		}
+		alreadySeenRefs := seenBefore[ref.URL]
+		isDuplicate := false
+		// Check if this reference already exists for this URL
+		for _, already := range alreadySeenRefs {
+			if refsAreEqual(already, ref) {
+				isDuplicate = true
+				break
+			}
+		}
+		if !isDuplicate {
+			seenBefore[ref.URL] = append(seenBefore[ref.URL], ref)
+			result = append(result, ref)
+		}
+	}
+
+	return result
+}
+
+func refsAreEqual(a, b grypeDB.Reference) bool {
+	if a.URL != b.URL {
+		return false
+	}
+
+	if len(a.Tags) != len(b.Tags) {
+		return false
+	}
+
+	for i := range a.Tags {
+		if a.Tags[i] != b.Tags[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Sometimes, upstream data has many or even hundreds of copies of the same reference. Rather than emitting all of this data, normalize and deduplicate it.

Fixes https://github.com/anchore/grype-db/issues/742