### PR TITLE
fix: increase max compression single file size to 25 GB

### DIFF
--- a/cmd/grype-db/cli/commands/cache_restore.go
+++ b/cmd/grype-db/cli/commands/cache_restore.go
@@ -366,7 +366,7 @@ const (
 	gb
 )
 
-const perFileReadLimit = 10 * gb
+const perFileReadLimit = 25 * gb
 
 // safeCopy limits the copy from the reader. This is useful when extracting files from archives to
 // protect against decompression bomb attacks.


### PR DESCRIPTION
Ideally this will be configurable rather than hard-coded, but this is a quick fix so we can get dbs building again