### PR TITLE
ci: warn when cache size close to extraction limit

### DIFF
--- a/.github/scripts/check-cache-size-alerts.sh
+++ b/.github/scripts/check-cache-size-alerts.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check for size warning logs in the output and send alerts if needed
+# This script is meant to be run after cache restore operations
+
+LOG_FILE="${1:-}"
+
+if [ -z "$LOG_FILE" ]; then
+    echo "Usage: $0 <log-file>"
+    exit 1
+fi
+
+if [ ! -f "$LOG_FILE" ]; then
+    echo "Log file not found: $LOG_FILE"
+    exit 1
+fi
+
+# Check for ERROR level size warnings (>=90%)
+if grep -q "file size is dangerously close to extraction limit" "$LOG_FILE"; then
+    echo "::error::Cache files are approaching size limits (>=90%)"
+    echo "CACHE_SIZE_ALERT=critical" >> "$GITHUB_ENV"
+    grep "file size is dangerously close to extraction limit" "$LOG_FILE" || true
+    exit 0
+fi
+
+# Check for WARN level size warnings (>=80%)
+if grep -q "file size is approaching extraction limit" "$LOG_FILE"; then
+    echo "::warning::Cache files are approaching size limits (>=80%)"
+    echo "CACHE_SIZE_ALERT=warning" >> "$GITHUB_ENV"
+    grep "file size is approaching extraction limit" "$LOG_FILE" || true
+    exit 0
+fi
+
+# Check for INFO level (>=50%)
+if grep -q "large file extracted" "$LOG_FILE"; then
+    echo "::notice::Large cache files detected (>=50% of limit)"
+    grep "large file extracted" "$LOG_FILE" || true
+fi
+
+echo "No cache size alerts detected"

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -83,6 +83,32 @@ jobs:
 
       - name: Pull vulnerability data
         run: make download-all-provider-cache
+        env:
+          GRYPE_DB_LOG_FILE: /tmp/cache-restore.log
+
+      - name: Check for cache size alerts
+        if: always()
+        run: |
+          if [ -f /tmp/cache-restore.log ]; then
+            .github/scripts/check-cache-size-alerts.sh /tmp/cache-restore.log
+          else
+            echo "No log file found, skipping cache size check"
+          fi
+
+      - name: Send Slack alert for cache size warnings
+        if: env.CACHE_SIZE_ALERT == 'critical' || env.CACHE_SIZE_ALERT == 'warning'
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e #v3.19.0
+        with:
+          status: custom
+          custom_payload: |
+            {
+              attachments: [{
+                color: '${{ env.CACHE_SIZE_ALERT }}' === 'critical' ? 'danger' : 'warning',
+                text: `Cache size alert (${{ env.CACHE_SIZE_ALERT }}): Files are approaching extraction limits. See workflow logs for details.`
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
 
       - name: Generate and upload DB
         run: |

--- a/cmd/grype-db/cli/commands/cache_restore_test.go
+++ b/cmd/grype-db/cli/commands/cache_restore_test.go
@@ -157,7 +157,7 @@ func TestHandleFile(t *testing.T) {
 			}
 			reader := bytes.NewReader([]byte(tt.content))
 
-			err := handleFile(fs, tt.path, reader)
+			err := handleFile(fs, tt.path, reader, 25*gb)
 			tt.wantErr(t, err)
 			if tt.verifyFunc != nil {
 				tt.verifyFunc(t, fs, tt.path, tt.content)

--- a/cmd/grype-db/cli/options/cache_restore.go
+++ b/cmd/grype-db/cli/options/cache_restore.go
@@ -9,7 +9,8 @@ var _ Interface = &CacheRestore{}
 
 type CacheRestore struct {
 	// bound options
-	DeleteExisting bool `yaml:"delete-existing" json:"delete-existing" mapstructure:"delete-existing"`
+	DeleteExisting bool   `yaml:"delete-existing" json:"delete-existing" mapstructure:"delete-existing"`
+	MaxFileSize    string `yaml:"max-file-size" json:"max-file-size" mapstructure:"max-file-size"`
 
 	// unbound options
 	// (none)
@@ -18,6 +19,7 @@ type CacheRestore struct {
 func DefaultCacheRestore() CacheRestore {
 	return CacheRestore{
 		DeleteExisting: false,
+		MaxFileSize:    "25GB",
 	}
 }
 
@@ -36,7 +38,7 @@ func (o *CacheRestore) BindFlags(flags *pflag.FlagSet, v *viper.Viper) error {
 	}
 
 	// set default values for non-bound struct items
-	// (none)
+	v.SetDefault("restore.max-file-size", o.MaxFileSize)
 
 	return nil
 }


### PR DESCRIPTION
The decompressors we use have a size limit to prevent DOS from malformed or large archives. However, the files we use are big and have tripped this limit incorrectly. Therefore, make the limit configurable and slack a warning when we are approaching the limit.