### PR TITLE
ci: increase runner size and ubuntu concurrency

### DIFF
--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -58,7 +58,7 @@ jobs:
   update-provider-multicore:
     name: "Update provider (multicore)"
     needs: discover-providers
-    runs-on: runs-on=${{ github.run_id }}/cpu=32/volume=80gb:gp3/family=r8+m8+r7+r6i+r6a+m7+m6i+m6a
+    runs-on: runs-on=${{ github.run_id }}-multicore-${{ strategy.job-index }}/cpu=32/volume=80gb:gp3/family=r8+m8+r7+r6i+r6a+m7+m6i+m6a
     timeout-minutes: 480
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:
@@ -115,7 +115,7 @@ jobs:
   update-provider:
     name: "Update provider"
     needs: discover-providers
-    runs-on: runs-on=${{ github.run_id }}/runner=large
+    runs-on: runs-on=${{ github.run_id }}-provider-${{ strategy.job-index }}/runner=large
     timeout-minutes: 480
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -57,7 +57,7 @@ jobs:
     if: ${{ github.event.inputs.publish-databases != 'false' }}
     name: "Generate and publish DBs"
     needs: discover-schema-versions
-    runs-on: runs-on=${{ github.run_id }}/runner=large
+    runs-on: runs-on=${{ github.run_id }}-publish-${{ strategy.job-index }}/runner=large
     strategy:
       matrix:
         schema-version: ${{fromJson(needs.discover-schema-versions.outputs.schema-versions)}}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -131,7 +131,7 @@ jobs:
   Acceptance-Test:
     name: "Acceptance tests"
     needs: Discover-Schema-Versions
-    runs-on: runs-on=${{ github.run_id }}/runner=large
+    runs-on: runs-on=${{ github.run_id }}-acceptance-${{ strategy.job-index }}/runner=large
     strategy:
       matrix:
         schema-version: ${{fromJson(needs.Discover-Schema-Versions.outputs.schema-versions)}}


### PR DESCRIPTION
The ubuntu provider is consistently timing out. It should be rewritten to use a more performant approach, but first today's Grype DB needs to be published. Temporarily raise the amount of compute available to the daily data sync jobs and increase the amount concurrency requested of the vunnel ubuntu provider.