### PR TITLE
ci: allow more time for ubuntu runner

### DIFF
--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -48,6 +48,7 @@ jobs:
     name: "Update provider"
     needs: discover-providers
     runs-on: runs-on=${{ github.run_id }}/runner=large
+    timeout-minutes: 420  # 7 hours; db publisher looks for this cache 8 hours later, but we need time to aggregate the cache
     # set the permissions granted to the github token to publish to ghcr.io
     permissions:
       contents: read

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -16,7 +16,7 @@ on:
 
   # run 7 AM (UTC) daily
   schedule:
-    - cron:  '0 7 * * *'
+    - cron:  '0 8 * * *'
 
 env:
   CGO_ENABLED: "0"


### PR DESCRIPTION
Several times the Ubuntu provider has failed to finish in time to publish that day's grype db. While work to make the provider more performant is ongoing, give it an extra hour to run to reduce the odds of this sort of timeout.