### PR TITLE
chore: publish listing file from github actions runner

### DIFF
--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -122,7 +122,7 @@ jobs:
 
     name: "Publish listing file"
     needs: generate-and-publish-dbs
-    runs-on: runs-on=${{ github.run_id }}/runner=large
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
There have been some surprising behaviors running this on Runs On. Since it is a very short job and worked fine before, just switch it back to a regular github actions runner