### PR TITLE
Add Root IO support to OSV transformer

### DIFF
--- a/pkg/process/v6/transformers/osv/test-fixtures/ROOT-APP-NPM-CVE-2022-25883.json
+++ b/pkg/process/v6/transformers/osv/test-fixtures/ROOT-APP-NPM-CVE-2022-25883.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "1.6.1",
+  "id": "ROOT-APP-NPM-CVE-2022-25883",
+  "modified": "2024-12-01T10:00:00Z",
+  "published": "2024-11-01T08:00:00Z",
+  "aliases": [
+    "CVE-2022-25883",
+    "GHSA-c2qf-rxjj-qqgw"
+  ],
+  "summary": "semver vulnerable to Regular Expression Denial of Service",
+  "details": "Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@rootio/semver"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "7.5.2-root.io.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25883"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/npm/node-semver/pull/564"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "database_specific": {
+    "source": "Root"
+  }
+}

--- a/pkg/process/v6/transformers/osv/test-fixtures/ROOT-APP-PYPI-CVE-2025-30473.json
+++ b/pkg/process/v6/transformers/osv/test-fixtures/ROOT-APP-PYPI-CVE-2025-30473.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "1.6.1",
+  "id": "ROOT-APP-PYPI-CVE-2025-30473",
+  "modified": "2024-12-15T14:30:00Z",
+  "published": "2024-12-10T09:00:00Z",
+  "aliases": [
+    "CVE-2025-30473"
+  ],
+  "summary": "requests vulnerable to improper certificate validation",
+  "details": "The requests library before version 2.31.0+root.io.1 contains a vulnerability in certificate validation that may allow man-in-the-middle attacks.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "rootio-requests"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.31.0+root.io.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30473"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+    }
+  ],
+  "database_specific": {
+    "source": "Root"
+  }
+}

--- a/pkg/process/v6/transformers/osv/test-fixtures/ROOT-OS-ALPINE-318-CVE-2000-0548.json
+++ b/pkg/process/v6/transformers/osv/test-fixtures/ROOT-OS-ALPINE-318-CVE-2000-0548.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.6.1",
+  "id": "ROOT-OS-ALPINE-318-CVE-2000-0548",
+  "modified": "2024-11-20T16:00:00Z",
+  "published": "2024-11-15T12:00:00Z",
+  "aliases": [
+    "CVE-2000-0548"
+  ],
+  "summary": "util-linux vulnerability in mount command",
+  "details": "The mount command in util-linux before version 2.38.1-r10071 has a vulnerability that could allow local privilege escalation.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Alpine:3.18",
+        "name": "rootio-util-linux"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.38.1-r10071"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2000-0548"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.alpinelinux.org/vuln/CVE-2000-0548"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "database_specific": {
+    "source": "Root"
+  }
+}

--- a/pkg/process/v6/transformers/osv/test-fixtures/ROOT-OS-DEBIAN-bookworm-CVE-2025-53014.json
+++ b/pkg/process/v6/transformers/osv/test-fixtures/ROOT-OS-DEBIAN-bookworm-CVE-2025-53014.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.6.1",
+  "id": "ROOT-OS-DEBIAN-bookworm-CVE-2025-53014",
+  "modified": "2024-12-10T11:00:00Z",
+  "published": "2024-12-05T10:00:00Z",
+  "aliases": [
+    "CVE-2025-53014"
+  ],
+  "summary": "imagemagick buffer overflow vulnerability",
+  "details": "ImageMagick versions before 8:7.1.1.43+dfsg1-1+deb13u1.root.io.1 contain a buffer overflow vulnerability that could lead to arbitrary code execution.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Debian:13",
+        "name": "rootio-imagemagick"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "8:7.1.1.43+dfsg1-1+deb13u1.root.io.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-53014"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security-tracker.debian.org/tracker/CVE-2025-53014"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "database_specific": {
+    "source": "Root"
+  }
+}

--- a/pkg/process/v6/transformers/osv/test-fixtures/ROOT-OS-UBUNTU-2004-CVE-2024-12345.json
+++ b/pkg/process/v6/transformers/osv/test-fixtures/ROOT-OS-UBUNTU-2004-CVE-2024-12345.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.6.1",
+  "id": "ROOT-OS-UBUNTU-2004-CVE-2024-12345",
+  "modified": "2024-11-25T13:00:00Z",
+  "published": "2024-11-20T10:00:00Z",
+  "aliases": [
+    "CVE-2024-12345"
+  ],
+  "summary": "openssl cryptographic weakness",
+  "details": "OpenSSL versions before 1.1.1f-1ubuntu2.root.io.1 contain a cryptographic weakness that could allow attackers to decrypt sensitive data.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Ubuntu:20.04",
+        "name": "rootio-openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.1.1f-1ubuntu2.root.io.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-12345"
+    },
+    {
+      "type": "WEB",
+      "url": "https://ubuntu.com/security/CVE-2024-12345"
+    }
+  ],
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
+  ],
+  "database_specific": {
+    "source": "Root"
+  }
+}

--- a/pkg/process/v6/transformers/osv/transform.go
+++ b/pkg/process/v6/transformers/osv/transform.go
@@ -94,8 +94,8 @@ func getAffectedPackages(vuln unmarshal.OSVVulnerability) []grypeDB.AffectedPack
 			BlobValue:       &grypeDB.PackageBlob{CVEs: vuln.Aliases},
 		}
 
-		// Extract qualifiers (CPE and RPM modularity)
-		qualifiers := getPackageQualifiers(affected, cpes, withCPE)
+		// Extract qualifiers (CPE, RPM modularity, and Root IO)
+		qualifiers := getPackageQualifiers(affected, cpes, withCPE, vuln)
 		if qualifiers != nil {
 			aph.BlobValue.Qualifiers = qualifiers
 		}
@@ -115,8 +115,8 @@ func getAffectedPackages(vuln unmarshal.OSVVulnerability) []grypeDB.AffectedPack
 }
 
 // getPackageQualifiers extracts package qualifiers from affected package data
-// including CPE information and RPM modularity
-func getPackageQualifiers(affected models.Affected, cpes any, withCPE bool) *grypeDB.PackageQualifiers {
+// including CPE information, RPM modularity, and Root IO markers
+func getPackageQualifiers(affected models.Affected, cpes any, withCPE bool, vuln unmarshal.OSVVulnerability) *grypeDB.PackageQualifiers {
 	var qualifiers *grypeDB.PackageQualifiers
 
 	// Handle CPE qualifiers (existing logic)
@@ -133,6 +133,15 @@ func getPackageQualifiers(affected models.Affected, cpes any, withCPE bool) *gry
 			qualifiers = &grypeDB.PackageQualifiers{}
 		}
 		qualifiers.RpmModularity = &rpmModularity
+	}
+
+	// Check if this is a Root IO package
+	if isRootIORecord(vuln) {
+		if qualifiers == nil {
+			qualifiers = &grypeDB.PackageQualifiers{}
+		}
+		rootIO := true
+		qualifiers.RootIO = &rootIO
 	}
 
 	return qualifiers
@@ -359,24 +368,45 @@ func getPackage(p models.Package) *grypeDB.Package {
 }
 
 // getPackageTypeFromEcosystem determines package type from OSV ecosystem
-// Currently only supports AlmaLinux; other ecosystems use PURL-based detection
+// Supports AlmaLinux and Root IO OS ecosystems (Alpine, Debian, Ubuntu)
+// Also supports Root IO language ecosystems (npm, pypi, maven)
 func getPackageTypeFromEcosystem(ecosystem string) pkg.Type {
 	if ecosystem == "" {
 		return ""
 	}
 
-	// Split ecosystem by colon to get OS name
-	parts := strings.Split(ecosystem, ":")
-	osName := strings.ToLower(parts[0])
+	ecosystemLower := strings.ToLower(ecosystem)
 
-	// Only handle AlmaLinux
-	if osName == almaLinux {
-		return pkg.RpmPkg
+	// Check for language ecosystems (Root IO)
+	switch ecosystemLower {
+	case "npm":
+		return pkg.NpmPkg
+	case "pypi", "python", "pip":
+		return pkg.PythonPkg
+	case "maven", "java":
+		return pkg.JavaPkg
 	}
 
-	// For other ecosystems (like Bitnami, npm, pypi, etc.), return empty type
-	// The package type will be determined from PURL if available
-	return ""
+	// Split ecosystem by colon to get OS name
+	parts := strings.Split(ecosystem, ":")
+	if len(parts) < 2 {
+		return ""
+	}
+	osName := strings.ToLower(parts[0])
+
+	// Handle OS ecosystems
+	switch osName {
+	case almaLinux:
+		return pkg.RpmPkg
+	case "alpine":
+		return pkg.ApkPkg
+	case "debian", "ubuntu":
+		return pkg.DebPkg
+	default:
+		// For other ecosystems (like Bitnami), return empty type
+		// The package type will be determined from PURL if available
+		return ""
+	}
 }
 
 func getReferences(vuln unmarshal.OSVVulnerability) []grypeDB.Reference {
@@ -460,8 +490,8 @@ func getSeverities(vuln unmarshal.OSVVulnerability) ([]grypeDB.Severity, error) 
 }
 
 // getOperatingSystemFromEcosystem extracts operating system information from OSV ecosystem field
-// Currently only supports AlmaLinux ecosystems
-// Example: "AlmaLinux:8" -> almalinux 8
+// Supports AlmaLinux and Root IO OS ecosystems (Alpine, Debian, Ubuntu)
+// Examples: "AlmaLinux:8" -> almalinux 8, "Alpine:3.18" -> alpine 3.18, "Ubuntu:20.04" -> ubuntu 20.04
 func getOperatingSystemFromEcosystem(ecosystem string) *grypeDB.OperatingSystem {
 	if ecosystem == "" {
 		return nil
@@ -475,8 +505,11 @@ func getOperatingSystemFromEcosystem(ecosystem string) *grypeDB.OperatingSystem 
 
 	osName := strings.ToLower(parts[0])
 
-	// Only handle AlmaLinux
-	if osName != almaLinux {
+	// Check if this is a supported OS
+	switch osName {
+	case almaLinux, "alpine", "debian", "ubuntu":
+		// Supported OS, continue processing
+	default:
 		return nil
 	}
 
@@ -510,16 +543,8 @@ func getOperatingSystemFromEcosystem(ecosystem string) *grypeDB.OperatingSystem 
 }
 
 // normalizeOSName normalizes operating system names for consistency
-// Currently only supports AlmaLinux
 func normalizeOSName(osName string) string {
-	osName = strings.ToLower(osName)
-
-	// Only handle AlmaLinux
-	if osName == almaLinux {
-		return almaLinux
-	}
-
-	return osName
+	return strings.ToLower(osName)
 }
 
 // isAdvisoryRecord checks if the OSV record is marked as an advisory
@@ -562,7 +587,7 @@ func getUnaffectedPackages(vuln unmarshal.OSVVulnerability) []grypeDB.Unaffected
 		uph := grypeDB.UnaffectedPackageHandle{
 			Package:         getPackage(affected.Package),
 			OperatingSystem: getOperatingSystemFromEcosystem(string(affected.Package.Ecosystem)),
-			BlobValue:       getUnaffectedBlob(vuln.Aliases, affected.Ranges, affected),
+			BlobValue:       getUnaffectedBlob(vuln.Aliases, affected.Ranges, affected, vuln),
 		}
 		uphs = append(uphs, uph)
 	}
@@ -575,15 +600,15 @@ func getUnaffectedPackages(vuln unmarshal.OSVVulnerability) []grypeDB.Unaffected
 
 // getUnaffectedBlob creates a package blob for unaffected packages (advisories)
 // For advisories, we need to invert the ranges to represent unaffected versions
-func getUnaffectedBlob(aliases []string, ranges []models.Range, affected models.Affected) *grypeDB.PackageBlob {
+func getUnaffectedBlob(aliases []string, ranges []models.Range, affected models.Affected, vuln unmarshal.OSVVulnerability) *grypeDB.PackageBlob {
 	var grypeRanges []grypeDB.Range
 	ecosystem := string(affected.Package.Ecosystem)
 	for _, r := range ranges {
 		grypeRanges = append(grypeRanges, getGrypeUnaffectedRangesFromRange(r, ecosystem)...)
 	}
 
-	// Extract qualifiers including RPM modularity
-	qualifiers := getPackageQualifiers(affected, nil, false)
+	// Extract qualifiers including RPM modularity and Root IO
+	qualifiers := getPackageQualifiers(affected, nil, false, vuln)
 
 	return &grypeDB.PackageBlob{
 		CVEs:       aliases,
@@ -686,4 +711,26 @@ func createUnaffectedRange(fixedVersion string, fixByVersion map[string]grypeDB.
 			Constraint: normalizeConstraint(constraint, rangeType),
 		},
 	}
+}
+
+// ============================================================================
+// Root IO Detection
+// ============================================================================
+
+const rootIOSourceIdentifier = "Root"
+
+// isRootIORecord checks if an OSV record is from Root IO by examining database_specific.source
+// This is used to apply Root IO-specific package qualifiers
+func isRootIORecord(vuln unmarshal.OSVVulnerability) bool {
+	if vuln.DatabaseSpecific == nil {
+		return false
+	}
+
+	source, ok := vuln.DatabaseSpecific["source"]
+	if !ok {
+		return false
+	}
+
+	sourceStr, ok := source.(string)
+	return ok && sourceStr == rootIOSourceIdentifier
 }

--- a/pkg/process/v6/transformers/osv/transform_test.go
+++ b/pkg/process/v6/transformers/osv/transform_test.go
@@ -711,7 +711,9 @@ func Test_getPackageQualifiers(t *testing.T) {
 	for _, testToRun := range tests {
 		test := testToRun
 		t.Run(test.name, func(tt *testing.T) {
-			got := getPackageQualifiers(test.affected, test.cpes, test.withCPE)
+			// Pass empty vuln for non-Root IO tests
+			emptyVuln := unmarshal.OSVVulnerability{}
+			got := getPackageQualifiers(test.affected, test.cpes, test.withCPE, emptyVuln)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("getPackageQualifiers() = %v, want %v", got, test.want)
 			}
@@ -721,4 +723,138 @@ func Test_getPackageQualifiers(t *testing.T) {
 
 func stringRef(s string) *string {
 	return &s
+}
+// Root IO Tests
+// ============================================================================
+
+func TestIsRootIORecord(t *testing.T) {
+	tests := []struct {
+		name string
+		vuln unmarshal.OSVVulnerability
+		want bool
+	}{
+		{
+			name: "Root IO record with database_specific.source",
+			vuln: unmarshal.OSVVulnerability{
+				DatabaseSpecific: map[string]interface{}{
+					"source": "Root",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Non-Root IO record",
+			vuln: unmarshal.OSVVulnerability{
+				DatabaseSpecific: map[string]interface{}{
+					"source": "GitHub",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "No database_specific field",
+			vuln: unmarshal.OSVVulnerability{
+				DatabaseSpecific: nil,
+			},
+			want: false,
+		},
+		{
+			name: "database_specific without source",
+			vuln: unmarshal.OSVVulnerability{
+				DatabaseSpecific: map[string]interface{}{
+					"other_field": "value",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "database_specific source is not string",
+			vuln: unmarshal.OSVVulnerability{
+				DatabaseSpecific: map[string]interface{}{
+					"source": 123,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			got := isRootIORecord(test.vuln)
+			if got != test.want {
+				t.Errorf("isRootIORecord() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTransformRootIOFixtures(t *testing.T) {
+	tests := []struct {
+		name        string
+		fixturePath string
+	}{
+		{
+			name:        "Root IO Alpine OS package",
+			fixturePath: "test-fixtures/ROOT-OS-ALPINE-318-CVE-2000-0548.json",
+		},
+		{
+			name:        "Root IO NPM package",
+			fixturePath: "test-fixtures/ROOT-APP-NPM-CVE-2022-25883.json",
+		},
+		{
+			name:        "Root IO PyPI package",
+			fixturePath: "test-fixtures/ROOT-APP-PYPI-CVE-2025-30473.json",
+		},
+		{
+			name:        "Root IO Debian package",
+			fixturePath: "test-fixtures/ROOT-OS-DEBIAN-bookworm-CVE-2025-53014.json",
+		},
+		{
+			name:        "Root IO Ubuntu package",
+			fixturePath: "test-fixtures/ROOT-OS-UBUNTU-2004-CVE-2024-12345.json",
+		},
+	}
+
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			vulns := loadFixture(t, test.fixturePath)
+			require.NotEmpty(t, vulns, "fixture should contain at least one vulnerability")
+
+			for _, vuln := range vulns {
+				// Verify it's detected as Root IO record
+				require.True(t, isRootIORecord(vuln), "should be detected as Root IO record")
+
+				// Transform the vulnerability
+				entries, err := Transform(vuln, inputProviderState())
+				require.NoError(t, err, "Transform should not return error")
+				require.NotEmpty(t, entries, "Transform should return at least one entry")
+
+				// Verify structure
+				for _, entry := range entries {
+					relatedEntries, ok := entry.Data.(transformers.RelatedEntries)
+					require.True(t, ok, "entry data should be RelatedEntries")
+
+					// Verify vulnerability handle
+					require.NotNil(t, relatedEntries.VulnerabilityHandle, "VulnerabilityHandle should not be nil")
+					require.Equal(t, "osv", relatedEntries.VulnerabilityHandle.ProviderID)
+					require.NotNil(t, relatedEntries.VulnerabilityHandle.BlobValue)
+
+					// Verify related packages
+					require.NotEmpty(t, relatedEntries.Related, "should have at least one related package")
+
+					for _, rel := range relatedEntries.Related {
+						aph, ok := rel.(grypeDB.AffectedPackageHandle)
+						require.True(t, ok, "related entry should be AffectedPackageHandle")
+						require.NotNil(t, aph.Package, "Package should not be nil")
+						require.NotEmpty(t, aph.Package.Name, "Package name should not be empty")
+						require.NotNil(t, aph.BlobValue, "BlobValue should not be nil")
+						require.NotEmpty(t, aph.BlobValue.CVEs, "CVEs should not be empty")
+						require.NotEmpty(t, aph.BlobValue.Ranges, "Ranges should not be empty")
+					}
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
  Enhances the OSV transformer to process Root IO vulnerability data
  and set the Root IO qualifier for proper NAK pattern matching.

  Implementation:
  - Add isRootIORecord() to detect Root IO records via database_specific.source
  - Set RootIO qualifier in getPackageQualifiers() for Root IO records
  - Extend getPackageTypeFromEcosystem() to support:
    - Root IO OS ecosystems: Alpine, Debian, Ubuntu
    - Root IO language ecosystems: npm, PyPI, Maven
  - Update getPackageQualifiers signature to pass full vuln record