### PR TITLE
ci: finish moving to i7i

### DIFF
--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -57,7 +57,7 @@ jobs:
     if: ${{ github.event.inputs.publish-databases != 'false' }}
     name: "Generate and publish DBs"
     needs: discover-schema-versions
-    runs-on: runs-on=${{ github.run_id }}-publish-${{ strategy.job-index }}/runner=large
+    runs-on: runs-on=${{ github.run_id }}-publish-${{ strategy.job-index }}/family=i7i/cpu=4+16/ram=32+128
     strategy:
       matrix:
         schema-version: ${{fromJson(needs.discover-schema-versions.outputs.schema-versions)}}


### PR DESCRIPTION
The `large` runner runs out of space and is slow. I missed a spot in https://github.com/anchore/grype-db/pull/799 😞 

Note: this apparently works and is fast: https://github.com/anchore/grype-db/actions/runs/20928743890
