### PR TITLE
ci: slack on cancelled jobs

### DIFF
--- a/.github/workflows/copy-listing-from-r2.yaml
+++ b/.github/workflows/copy-listing-from-r2.yaml
@@ -48,7 +48,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
 
       - uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e #v3.19.0
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+        if: ${{ always() && job.status != 'success' && env.SLACK_NOTIFICATIONS == 'true' }}
         with:
           status: ${{ job.status }}
           fields: workflow,eventName,job

--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -103,7 +103,7 @@ jobs:
           text: Daily Data Sync for ${{ matrix.provider }} failed
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+        if: ${{ always() && job.status != 'success' && env.SLACK_NOTIFICATIONS == 'true' }}
 
       - name: Upload the provider workspace state
         # even if the job fails, we want to upload yesterdays cache as todays cache to continue the DB build
@@ -159,7 +159,7 @@ jobs:
           text: Daily Data Sync for ${{ matrix.provider }} failed
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+        if: ${{ always() && job.status != 'success' && env.SLACK_NOTIFICATIONS == 'true' }}
 
       - name: Upload the provider workspace state
         # even if the job fails, we want to upload yesterdays cache as todays cache to continue the DB build

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -105,7 +105,7 @@ jobs:
           text: Publishing the Grype DB has failed (schema ${{ matrix.schema-version }})
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+        if: ${{ always() && job.status != 'success' && env.SLACK_NOTIFICATIONS == 'true' }}
 
   publish-listing-file:
     # fun! https://github.com/actions/runner/issues/491#issuecomment-850884422
@@ -153,7 +153,7 @@ jobs:
           text: Publishing the Grype DB listing file has failed
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ failure() && env.SLACK_NOTIFICATIONS == 'true' }}
+        if: ${{ always() && job.status != 'success' && env.SLACK_NOTIFICATIONS == 'true' }}
 
   sync-listing-file-to-s3:
     name: "Sync listing file to S3"


### PR DESCRIPTION
It seems like jobs that failed because of a timeout communicating with the runner end up marked as cancelled not failed and don't slack the team. For critical jobs like the daily db publisher, slack on all statuses besides success, because a skipped or cancelled job would also be surprising.

In https://github.com/anchore/grype-db/issues/801 we saw a report that the daily data sync had failed but our alerting hadn't triggered. This PR attempts to address that.