### PR TITLE
ci: allow overriding provider selection

### DIFF
--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -2,6 +2,12 @@ name: "Daily Data Sync"
 on:
   # allow for kicking off data syncs manually
   workflow_dispatch:
+    inputs:
+      providers:
+        description: 'Comma-separated list of providers to sync (e.g., "nvd,github,alpine"). Leave empty to sync all providers.'
+        required: false
+        default: ''
+        type: string
 
   # run midnight (UTC) daily
   schedule:
@@ -41,9 +47,15 @@ jobs:
 
       - name: Read configured providers
         id: read-providers
-        # TODO: honor CI overrides
         run: |
-          content=`make show-providers`
+          input_providers="${{ inputs.providers }}"
+          if [ -n "$input_providers" ]; then
+            # Convert comma-separated input to JSON array
+            content=$(echo "$input_providers" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R . | jq -s -c .)
+          else
+            # Use all configured providers
+            content=$(make show-providers)
+          fi
           echo "providers=$content" >> $GITHUB_OUTPUT
 
       - name: Split providers by concurrency needs


### PR DESCRIPTION
This permits us to re-run a comma-separated list of providers instead of the full set of providers during a daily data sync, if for example a distro contacts us and asks for a particular data fix.

There was already a TODO for this, and it would have made https://github.com/anchore/grype-db/issues/805 a little cheaper / easier.