### PR TITLE
ci: fix matrix jobs for empty inputs

### DIFF
--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -70,6 +70,7 @@ jobs:
   update-provider-multicore:
     name: "Update provider (multicore)"
     needs: discover-providers
+    if: ${{ needs.discover-providers.outputs.multicore-providers != '[]' }}
     runs-on: runs-on=${{ github.run_id }}-multicore-${{ strategy.job-index }}/cpu=32/volume=80gb:gp3/family=r8+m8+r7+r6i+r6a+m7+m6i+m6a
     timeout-minutes: 480
     # set the permissions granted to the github token to publish to ghcr.io
@@ -127,6 +128,7 @@ jobs:
   update-provider:
     name: "Update provider"
     needs: discover-providers
+    if: ${{ needs.discover-providers.outputs.other-providers != '[]' }}
     runs-on: runs-on=${{ github.run_id }}-provider-${{ strategy.job-index }}/runner=large
     timeout-minutes: 480
     # set the permissions granted to the github token to publish to ghcr.io


### PR DESCRIPTION
Previously, if the input for provider selection resulted in either empty providers or empty multicore providers, the empty branch's matrix job would be marked as failed. Now skip it instead.

Example of run incorrectly marked as failed: https://github.com/anchore/grype-db/actions/runs/21000661315

Example of run from this branch (couldn't test before because IIRC inputs are defined on `main`.): https://github.com/anchore/grype-db/actions/runs/21001123214