### PR TITLE
ci: enable more frequent runs of incremental providers

### DIFF
--- a/.github/scripts/aggregate-all-provider-cache.py
+++ b/.github/scripts/aggregate-all-provider-cache.py
@@ -35,12 +35,12 @@ def download_provider(provider: str, status: dict, lock: threading.Lock, verbose
     try:
         if verbose:
             subprocess.run(
-                f"make download-provider-cache provider={provider}",
+                f"make download-provider-cache provider={provider} date=latest",
                 shell=True, check=True,
             )
         else:
             subprocess.run(
-                f"make download-provider-cache provider={provider}",
+                f"make download-provider-cache provider={provider} date=latest",
                 shell=True, check=True,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )

--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -9,6 +9,18 @@ on:
         default: ''
         type: string
 
+  # allow other workflows to call this one
+  workflow_call:
+    inputs:
+      providers:
+        description: 'Comma-separated list of providers to sync. Leave empty to sync all providers.'
+        required: false
+        default: ''
+        type: string
+    secrets:
+      SLACK_TOOLBOX_WEBHOOK_URL:
+        required: false
+
   # run midnight (UTC) daily
   schedule:
     - cron: "0 0 * * *"
@@ -47,11 +59,12 @@ jobs:
 
       - name: Read configured providers
         id: read-providers
+        env:
+          INPUT_PROVIDERS: ${{ inputs.providers }}
         run: |
-          input_providers="${{ inputs.providers }}"
-          if [ -n "$input_providers" ]; then
+          if [ -n "$INPUT_PROVIDERS" ]; then
             # Convert comma-separated input to JSON array
-            content=$(echo "$input_providers" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R . | jq -s -c .)
+            content=$(echo "$INPUT_PROVIDERS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R . | jq -s -c .)
           else
             # Use all configured providers
             content=$(make show-providers)

--- a/.github/workflows/daily-db-publisher-r2.yaml
+++ b/.github/workflows/daily-db-publisher-r2.yaml
@@ -14,9 +14,9 @@ on:
         required: true
         default: true
 
-  # run 7 AM (UTC) daily
+  # run 6 AM (UTC) daily
   schedule:
-    - cron:  '0 8 * * *'
+    - cron:  '0 6 * * *'
 
 env:
   CGO_ENABLED: "0"

--- a/.github/workflows/incremental-data-sync.yaml
+++ b/.github/workflows/incremental-data-sync.yaml
@@ -1,0 +1,43 @@
+name: "Incremental Data Sync"
+on:
+  # allow for kicking off incremental syncs manually
+  workflow_dispatch:
+
+  # run 8 and 16 hours after the daily sync (which runs at midnight UTC)
+  schedule:
+    - cron: "0 8 * * *"
+    - cron: "0 16 * * *"
+
+permissions: {}
+
+jobs:
+  discover-incremental-providers:
+    name: "Discover incremental providers"
+    runs-on: ubuntu-latest
+    if: github.repository == 'anchore/grype-db' # only run for main repo
+    permissions:
+      contents: read
+    outputs:
+      providers: ${{ steps.get-providers.outputs.providers }}
+    steps:
+      - name: Get incremental providers
+        id: get-providers
+        run: |
+          # Use vunnel (via Docker) to list providers tagged as incremental
+          # Convert JSON array to comma-separated string for the called workflow
+          json_list=$(docker run --rm ghcr.io/anchore/vunnel:latest list --tag incremental -o json)
+          csv_list=$(echo "$json_list" | jq -r 'join(",")')
+          echo "providers=$csv_list" >> $GITHUB_OUTPUT
+
+  sync-providers:
+    name: "Sync incremental providers"
+    needs: discover-incremental-providers
+    if: needs.discover-incremental-providers.outputs.providers != ''
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/daily-data-sync.yaml
+    with:
+      providers: ${{ needs.discover-incremental-providers.outputs.providers }}
+    secrets:
+      SLACK_TOOLBOX_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}


### PR DESCRIPTION
Here an "incremental" provider is a vunnel provider that benefits from more frequent runs, for example by asking an API for vulnerabilities that have changed since the last successful run.

These providers run for less time if they are run more often, so the hosting costs of running them more often do not scale linearly with the frequency with which they are run. But more importantly they are more reliable if they are run more often, because they are processing a smaller change set, and so fewer things can go wrong.

In order to support the changed asynchrony model between the data sync and db publisher jobs, configure the download provider cache script to ask for the latest build of each provider rather than the one tagged with the current date.

Implement the incremental-data-sync as a workflow that invokes the daily-data-sync workflow with a subset of providers and on a different cron.