### PR TITLE
ci: fix incremental providers list

### DIFF
--- a/.github/workflows/incremental-data-sync.yaml
+++ b/.github/workflows/incremental-data-sync.yaml
@@ -24,9 +24,9 @@ jobs:
         id: get-providers
         run: |
           # Use vunnel (via Docker) to list providers tagged as incremental
-          # Convert JSON array to comma-separated string for the called workflow
+          # Output is array of objects like [{"name": "nvd", ...}], extract names and join
           json_list=$(docker run --rm ghcr.io/anchore/vunnel:latest list --tag incremental -o json)
-          csv_list=$(echo "$json_list" | jq -r 'join(",")')
+          csv_list=$(echo "$json_list" | jq -r '[.providers[].name] | join(",")')
           echo "providers=$csv_list" >> $GITHUB_OUTPUT
 
   sync-providers:


### PR DESCRIPTION
Previous commit parsed vunnel json output incorrectly.

This is a follow up to https://github.com/anchore/grype-db/pull/808 which had a bug in parsing vunnel's json output.

Testing better this time:

``` sh
❯ json_list=$(docker run --rm ghcr.io/anchore/vunnel:latest list --tag incremental -o json)
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
❯ csv_list=$(echo "$json_list" | jq -r '[.providers[].name] | join(",")')
❯ echo $csv_list
amazon,github,nvd,rhel,ubuntu
```

Test run: https://github.com/anchore/grype-db/actions/runs/21008270099