### PR TITLE
ci: add fallback-version to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ source = "uv-dynamic-versioning"
 [tool.uv-dynamic-versioning]
 vcs = "git"
 style = "semver"
+fallback-version = "0.0.0"
 
 [tool.pytest.ini_options]
 testpaths = ["manager/tests"]


### PR DESCRIPTION
Otherwise, dependabot will try to compute a semver version for the current package when attempting a dependency upgrade, which will fail without fallback. With the fallback, the inability of dependabot to integrate with the uv-dynamic-versioning plugin that is used to compute release versions will be automatically ignored, allowing dependabot to work again.