### PR TITLE
ci: group uv dependencies by minor and patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,8 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 7
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Otherwise, there is a lot of CI time spent individually testing minor changes to PyPI packages, and this testing is expensive in terms of time and infrastructure.