### PR TITLE
ci: make download-provider-cache retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,8 +211,8 @@ ci-oras-ghcr-login:
 
 .PHONY: download-provider-cache
 download-provider-cache:
-	$(call title,Downloading and restoring todays "$(provider)" provider data cache)
-	@bash -c "$(ORAS) pull $(ORAS_FLAGS) $(GRYPE_DB_DATA_IMAGE_NAME)/$(provider):$(date) || (echo 'no data cache found for today' && exit 1)"
+	$(call title,Downloading and restoring "$(provider)" provider data cache ($(date)))
+	@bash -c "$(ORAS) pull $(ORAS_FLAGS) $(GRYPE_DB_DATA_IMAGE_NAME)/$(provider):$(date) || (echo 'no data cache found for $(date)' && exit 1)"
 	$(GRYPE_DB) cache restore --path .cache/vunnel/$(provider)/grype-db-cache.tar.gz
 	@rm -rf .cache/vunnel/$(provider)
 


### PR DESCRIPTION
Since the clients of the cache now download every item in the cache separately, a few jobs have failed with transient network faults on one of the several providers. Previously, these faults could cause the whole job to fail, and were reported merely as "make download-provider-cache provider=<provider> failed: exit code 2" which is not enough information to troubleshoot. Therefore, capture some stdout and stderr from downloading the provider cache, and retry each provider once.