### PR TITLE
turn on EOL provider

### DIFF
--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -15,6 +15,7 @@ expected-providers:
   - chainguard-libraries
   - debian
   - echo
+  - eol
   - epss
   - github
   - kev

--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -20,6 +20,7 @@ provider:
     - name: chainguard-libraries
     - name: debian
     - name: echo
+    - name: eol
     - name: epss
     - name: github
     - name: kev


### PR DESCRIPTION
Data sync succeeds on this branch: https://github.com/anchore/grype-db/actions/runs/21399725249/job/61607370444

Building and importing db from this branch locally works as intended.