### PR TITLE
ci: revert eol from validate

### DIFF
--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -15,7 +15,6 @@ expected-providers:
   - chainguard-libraries
   - debian
   - echo
-  - eol
   - epss
   - github
   - kev


### PR DESCRIPTION
So we had a confluence of silly things happen:

1. I enabled auto merge on https://github.com/anchore/grype-db/pull/849
2. Branch protections were wrong, so https://github.com/anchore/grype-db/pull/849 went in without actually passing db-acceptance schema=6 validation job
3. Said db acceptance job uses `latest` not `main` to exercise grype-db, so the db-acceptance schema=6 job will fail until we get a grype-db release out that has an EOL data transformer in it
4. The release job blocks on `main` having green CI (which is blocked on the release).

Therefore, in addition to follow up actions to make this be less dumb, we need to revert the assertion that the `eol` data is present during db acceptance, because it won't be until we can get a release out.