### PR TITLE
feat: prepare to receive erlang data

### DIFF
--- a/pkg/process/v5/transformers/github/transform.go
+++ b/pkg/process/v5/transformers/github/transform.go
@@ -30,8 +30,8 @@ func buildGrypeNamespace(group string) (namespace.Namespace, error) {
 		switch feedGroupLang {
 		case "nuget":
 			syftLanguage = syftPkg.Dotnet
-		case "github-action":
-			// we don't want to error out on this, but grype at this version does not support github-action matching
+		case "github-action", "erlang":
+			// we don't want to error out on this, but grype at this version does not support these ecosystems
 			return nil, errSkip
 		default:
 			return nil, fmt.Errorf("unable to determine grype namespace for enterprise namespace=%s", group)

--- a/pkg/process/v6/transformers/github/transform.go
+++ b/pkg/process/v6/transformers/github/transform.go
@@ -219,6 +219,8 @@ func getPackageType(ecosystem string) pkg.Type {
 		return pkg.SwiftPkg
 	case "rubygems", "ruby", "gem":
 		return pkg.GemPkg
+	case "erlang", "hex", "elixir":
+		return pkg.HexPkg
 	case "apk":
 		return pkg.ApkPkg
 	case "rpm":


### PR DESCRIPTION

Map GitHub ERLANG package ecosystem to Hex packages in schema v6 so that
these and be queried for in Grype.

Also, disable Erlang packages in v5. This has not effect on actual v5
matching, because v5 has never had erlang, but the transformer in v5
can't handle having one ecosystem that maps to two languages, so skip
these in v5 so that we can turn them on for v6.

See also https://github.com/anchore/grype/pull/3194 and https://github.com/anchore/vunnel/pull/747
