### PR TITLE
feat: update grype to pull in postmarketos alias mappings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.5.3
 	github.com/anchore/go-logger v0.0.0-20250318195838-07ae343dd722
-	github.com/anchore/grype v0.107.1
+	github.com/anchore/grype v0.107.2-0.20260209135337-520be9fa9a96
 	github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115
 	github.com/anchore/syft v1.41.2
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.107.1 h1:N7EIlJfuq7RKA5nSgXPxOfifyB8EABYd2vP+CJwL1bY=
-github.com/anchore/grype v0.107.1/go.mod h1:DilbSyGMuYZREWL/tIZYOA4PedC2X2FOaEMAmQaNGhg=
+github.com/anchore/grype v0.107.2-0.20260209135337-520be9fa9a96 h1:8/YQqNItaG+yQnqSCWrKiiZZwTblOeVfxlWhEOIfrJY=
+github.com/anchore/grype v0.107.2-0.20260209135337-520be9fa9a96/go.mod h1:DilbSyGMuYZREWL/tIZYOA4PedC2X2FOaEMAmQaNGhg=
 github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115 h1:ZyRCmiEjnoGJZ1+Ah0ZZ/mKKqNhGcUZBl0s7PTTDzvY=
 github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
 github.com/anchore/stereoscope v0.1.19 h1:1G5LVmRN1Sz6qNezpVAEeN7QfWwCE9zw9TJK1ZGnkvw=


### PR DESCRIPTION
This brings in the updates necesary to build a correct db for https://github.com/anchore/grype/pull/3182