### PR TITLE
feat: enable photon vunnel provider

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -27,6 +27,7 @@ provider:
     - name: mariner
     - name: minimos
     - name: oracle
+    - name: photon
     - name: rhel
     - name: secureos
     - name: sles


### PR DESCRIPTION
Running data sync for this provider from this branch: https://github.com/anchore/grype-db/actions/runs/21875685527 jk that one: https://github.com/anchore/grype-db/actions/runs/21883682413