### PR TITLE
ci(db-build): much larger batch

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -43,7 +43,7 @@ provider:
       NVD_API_KEY: $NVD_API_KEY
 
 build:
-  batch-size: 40000
+  batch-size: 10000
 
 pull:
   parallelism: 4


### PR DESCRIPTION
Now that we have configurable batch sizes, turn the batch size up very far to get even faster db builds.

Test run from this branch with 10K: https://github.com/anchore/grype-db/actions/runs/21947144161 - saves 2 minutes over https://github.com/anchore/grype-db/actions/runs/21936141571/job/63350685208

Trying with 40K: https://github.com/anchore/grype-db/actions/runs/21950323873 - slower than 10K - going back to 10K