### PR TITLE
feat: turn up hummingbird provider

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -24,6 +24,7 @@ provider:
     - name: epss
     - name: fedora
     - name: github
+    - name: hummingbird
     - name: kev
     - name: mariner
     - name: minimos


### PR DESCRIPTION
Running the data sync for the new provider: https://github.com/anchore/grype-db/actions/runs/24148858742