### PR TITLE
Tighten workflow permissions and modernize release quality gate

### DIFF
--- a/.github/workflows/daily-data-sync.yaml
+++ b/.github/workflows/daily-data-sync.yaml
@@ -29,6 +29,8 @@ env:
   CGO_ENABLED: "0"
   SLACK_NOTIFICATIONS: true
 
+permissions: {}
+
 jobs:
   discover-providers:
     name: "Discover vulnerability providers"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,119 +1,38 @@
 name: "Release"
+
+permissions: {}
+
+# there should never be two releases in progress at the same time
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
-      bypassQualityGate:
-        description: bypass the quality gate check
-        required: false
-        default: false
-        type: boolean
-
-permissions:
-  contents: read
 
 jobs:
 
-  quality-gate:
-    environment: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
+  version-available:
+    uses: anchore/workflows/.github/workflows/check-version-available.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      version: ${{ github.event.inputs.version }}
 
-      - name: Check if tag already exists
-        # note: this will fail if the tag already exists
-        env:
-          VERSION: ${{ github.event.inputs.version }}
-        run: |
-          [[ "$VERSION" == v* ]] || (echo "version '$VERSION' does not have a 'v' prefix" && exit 1)
-          git tag $VERSION
-
-      - name: Check static analysis results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
-        id: static-analysis
-        if: ${{ github.event.inputs.bypassQualityGate != 'true' }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Static analysis"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check unit test results (go)
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
-        id: unit-go
-        if: ${{ github.event.inputs.bypassQualityGate != 'true' }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Unit tests (Go)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check unit test results (python)
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
-        id: unit-python
-        if: ${{ github.event.inputs.bypassQualityGate != 'true' }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Unit tests (Python)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check cli test results (go-linux)
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
-        id: cli-go-linux
-        if: ${{ github.event.inputs.bypassQualityGate != 'true' }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "CLI tests (Go-Linux)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check cli test results (python)
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
-        id: cli-python
-        if: ${{ github.event.inputs.bypassQualityGate != 'true' }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "CLI tests (Python)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check acceptance test results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
-        id: acceptance
-        if: ${{ github.event.inputs.bypassQualityGate != 'true' }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "DB acceptance tests"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Quality gate
-        if: (steps.static-analysis.outputs.conclusion != 'success' || steps.unit-go.outputs.conclusion != 'success' || steps.cli-go-linux.outputs.conclusion != 'success' || steps.unit-python.outputs.conclusion != 'success' || steps.cli-python.outputs.conclusion != 'success' || steps.acceptance.outputs.conclusion != 'success') && github.event.inputs.bypassQualityGate != 'true'
-        env:
-          STATIC_ANALYSIS_STATUS: ${{ steps.static-analysis.outputs.conclusion }}
-          GO_UNIT_STATUS: ${{ steps.unit-go.outputs.conclusion }}
-          PYTHON_UNIT_STATUS: ${{ steps.unit-python.outputs.conclusion }}
-          GO_CLI_LINUX_STATUS: ${{ steps.cli-go-linux.outputs.conclusion }}
-          PYTHON_CLI_STATUS: ${{ steps.cli-python.outputs.conclusion }}
-          ACCEPTANCE_STATUS: ${{ steps.acceptance.outputs.conclusion }}
-        run: |
-          echo "Static Analysis Status: $STATIC_ANALYSIS_STATUS"
-          echo "Go Unit Test Status: $GO_UNIT_STATUS"
-          echo "Python Unit Test Status: $PYTHON_UNIT_STATUS"
-          echo "Go CLI Test (Linux) Status: $GO_CLI_LINUX_STATUS"
-          echo "Python CLI Test Status: $PYTHON_CLI_STATUS"
-          echo "DB Acceptance Test Status: $ACCEPTANCE_STATUS"
-          false
+  check-gate:
+    permissions:
+      checks: read   # required for getting the status of specific check names
+    uses: anchore/workflows/.github/workflows/check-gate.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      # these are checks that should be run on pull-request and merges to main.
+      # we do NOT want to kick off a release if these have not been verified on main.
+      # Please see the validations.yaml workflow for the names that should be used here.
+      checks: '["Build snapshot artifacts", "CLI tests", "DB acceptance tests", "Discover supported schema versions", "Static analysis", "Unit tests"]'
 
   release:
-    needs:
-      - quality-gate
-    if: always() && (needs.quality-gate.result == 'success' || needs.quality-gate.result == 'skipped')
+    needs: [check-gate, version-available]
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       # these are checks that should be run on pull-request and merges to main.
       # we do NOT want to kick off a release if these have not been verified on main.
       # Please see the validations.yaml workflow for the names that should be used here.
-      checks: '["Build snapshot artifacts", "CLI tests", "DB acceptance tests", "Discover supported schema versions", "Static analysis", "Unit tests"]'
+      checks: '["Build snapshot artifacts", "CLI tests (Go-Linux)", "CLI tests (Python)", "DB acceptance tests", "Discover supported schema versions", "Static analysis", "Unit tests (Go)", "Unit tests (Python)"]'
 
   release:
     needs: [check-gate, version-available]

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -11,8 +11,7 @@ on:
 env:
   CGO_ENABLED: "0"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 


### PR DESCRIPTION
Replaces the hand-rolled quality-gate job in release.yaml with the canonical check-version-available and check-gate reusable workflows, removes the bypassQualityGate workflow_dispatch input, and sets workflow-level permissions: {} where it was previously contents: read.

Changes:
- release.yaml: drop bypassQualityGate input, replace quality-gate job with version-available + check-gate reusable workflows, add concurrency group, set permissions: {}
- validate-github-actions.yaml, validations.yaml: workflow-level permissions: contents: read → permissions: {}
- daily-data-sync.yaml: add workflow-level permissions: {}