### PR TITLE
ci: delete existing on-disk grype-db cache during restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ ci-oras-ghcr-login:
 download-provider-cache:
 	$(call title,Downloading and restoring "$(provider)" provider data cache ($(date)))
 	@bash -c "$(ORAS) pull $(ORAS_FLAGS) $(GRYPE_DB_DATA_IMAGE_NAME)/$(provider):$(date) || (echo 'no data cache found for $(date)' && exit 1)"
-	$(GRYPE_DB) cache restore --path .cache/vunnel/$(provider)/grype-db-cache.tar.gz
+	$(GRYPE_DB) cache restore --path .cache/vunnel/$(provider)/grype-db-cache.tar.gz --delete-existing
 	@rm -rf .cache/vunnel/$(provider)
 
 .PHONY: refresh-provider-cache


### PR DESCRIPTION
We should ensure the existing cache is removed on disk prior to restore otherwise any files that were already at the target location but are not actually intended to be part of the cache will end up persisted in the next cache