### PR TITLE
chore: unpin go patch version in CI

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -12,7 +12,8 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.26.2"
+    # unpin from patch version so that deps bumps in grype that bump go don't break CI/db builds here
+    default: "1.26"
   python-version:
     description: "Python version to install"
     required: true


### PR DESCRIPTION
Recently dependabot PRs bumped the minimum go version to use with Grype, which broke the quality gate tests in this repository. Therefore, unpin the Go patch version. Pinning the Go patch version is recommended for deterministic release artifacts, but here we are not building Go projects for release as often as we are execing Go projects to get them to run, so a looser Go version pin seems appropriate.