### PR TITLE
Pass contents: read to check-gate workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
 
   check-gate:
     permissions:
+      contents: read
       checks: read   # required for getting the status of specific check names
     uses: anchore/workflows/.github/workflows/check-gate.yaml@b3e328b5ae31ba96297e2ed9a6124e5e6352a4c5 # v0.7.0
     with:


### PR DESCRIPTION
Otherwise the workflow doesn't have enough permissions to do its job.

See https://github.com/anchore/grype/pull/3486 - same issue, different repo.