### PR TITLE
Pull grype to get go vuln db provider and enable it

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -24,6 +24,7 @@ provider:
     - name: epss
     - name: fedora
     - name: github
+    - name: govulndb
     - name: hummingbird
     - name: kev
     - name: mariner

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.5.3
 	github.com/anchore/go-logger v0.1.0
-	github.com/anchore/grype v0.113.0
+	github.com/anchore/grype v0.113.1-0.20260603160810-7e47096960cb
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/anchore/go-sync v0.1.0 h1:1TEZM7jISrvtoBMOF79xP0caQKASAtgW1yKqc0EjyZg
 github.com/anchore/go-sync v0.1.0/go.mod h1:Iposeub0kHipoTei1icj4Tys0SJN+cCdxEnkS7bZUFs=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.113.0 h1:zn4nDfToSc6Qg/4HIIgvon2Zpl5lO0SCFBYKkKFFWXY=
-github.com/anchore/grype v0.113.0/go.mod h1:UzRNWNyvQuLND6vX4wPLKbXHTHQALsubXQn59GefZDc=
+github.com/anchore/grype v0.113.1-0.20260603160810-7e47096960cb h1:g2Tdy9pXsGXSxyyaJ+1j+SIEpu8NkAVi68px1mJwwOQ=
+github.com/anchore/grype v0.113.1-0.20260603160810-7e47096960cb/go.mod h1:UzRNWNyvQuLND6vX4wPLKbXHTHQALsubXQn59GefZDc=
 github.com/anchore/packageurl-go v0.2.0 h1:CkrM4RMUwrEGAiE1OVlxaZNzWj0TuHRey7o4T/EAErk=
 github.com/anchore/packageurl-go v0.2.0/go.mod h1:2JCgOQMIsqZ7TmliXG4PnUthPJAKE3mWQbsW2XHjAOE=
 github.com/anchore/stereoscope v0.2.0 h1:8haOu2ugLymmxvyfrZR7OTBFiRFRBh5LlNUtRrSRoxI=


### PR DESCRIPTION
Pull in https://github.com/anchore/grype/pull/3485 and enable https://github.com/anchore/vunnel/pull/1172