### PR TITLE
release pipeline refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,4 @@
 # Dependabot configuration
-#
-# Grouping behavior (see inline comments for details):
-#   - Minor + patch updates: grouped into a single PR per ecosystem
-#   - Major version bumps: individual PR per dependency
-#   - Security updates: individual PR per dependency
-#
-# Note: "patch" refers to semver version bumps (1.2.3 -> 1.2.4), not security fixes.
-# Security updates are identified separately via GitHub's Advisory Database and
-# can be any version bump (patch, minor, or major) that fixes a known CVE.
-
 version: 2
 
 updates:
@@ -28,14 +18,6 @@ updates:
       - dependency-name: "github.com/aquasecurity/go-version"
       - dependency-name: "github.com/knqyf263/go-apk-version"
       - dependency-name: "github.com/knqyf263/go-deb-version"
-    groups:
-      go-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directories:
@@ -49,14 +31,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    groups:
-      actions-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -68,11 +42,3 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 7
-    groups:
-      actions-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,11 @@ on:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
+      skip-checks:
+        description: skip the check-gate (release even if checks haven't passed on main)
+        type: boolean
+        default: false
+        required: false
 
 jobs:
 
@@ -24,6 +29,7 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    if: ${{ !inputs.skip-checks }}
     permissions:
       contents: read
       checks: read   # required for getting the status of specific check names
@@ -36,6 +42,14 @@ jobs:
 
   release:
     needs: [check-gate, version-available]
+    # run even when check-gate is skipped, but never when version-available
+    # failed/was skipped, nor when check-gate failed or was cancelled. note:
+    # always() disables the implicit success() gate on ALL needs, so the
+    # version-available requirement must be re-asserted explicitly here.
+    if: >-
+      ${{ always()
+          && needs.version-available.result == 'success'
+          && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
     permissions:
       contents: write
       packages: write
@@ -57,11 +71,13 @@ jobs:
 
       - name: Tag release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # for pushing tags (does not inherit workflow permissions)
+          TAG_TOKEN: ${{ secrets.TAG_TOKEN }}
           VERSION: ${{ github.event.inputs.version }}
+          REPO: ${{ github.repository }}
         run: |
-          git tag $VERSION
-          git push origin --tags
+          git tag "$VERSION"
+          git push "https://x-access-token:${TAG_TOKEN}@github.com/${REPO}" "$VERSION"
 
       - name: Build release artifacts
         run: make ci-release

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,1 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        # anchore/workflows is an internal repository; using @main is acceptable
-        anchore/*: any
+rules: {}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -83,8 +83,15 @@ issues:
   uniq-by-line: false
 formatters:
   enable:
+    - gci
     - gofmt
-    - goimports
+  settings:
+    gci:
+      # See https://golangci-lint.run/docs/formatters/configuration/#gci
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default  # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/anchore)
   exclusions:
     generated: lax
     paths:


### PR DESCRIPTION
quick pass refactoring grype-db's release pipeline:

- release.yaml: switched the "Tag release" step to push the tag with TAG_TOKEN instead of GITHUB_TOKEN (for pushing tags; doesn't inherit workflow permissions and can trigger downstream tag-triggered workflows)
- added a skip-checks workflow_dispatch input + wired check-gate to be skippable via `if: ${{ !inputs.skip-checks }}`
- added the release-job `if:` guard so it still runs when check-gate is skipped, but never when version-available failed/was skipped or check-gate failed/was cancelled
- dependabot.yml: dropped all grouping (go-minor-patch / actions-minor-patch) so updates come as individual PRs, and trimmed the stale grouping comment block
- zizmor.yml: removed the unpinned-uses config (only rule present) -> now `rules: {}`
- golangci.yaml: swapped goimports for the native gci formatter (gofmt + gci, standard/default/prefix(github.com/anchore))

notes for the reviewer:
- this repo does NOT use go-make / there's no `.make` dir, and `make ci-release` is goreleaser-based and does NOT create/push the git tag. The separate "Tag release" step is the only tagging mechanism, so it was kept (not removed) and just switched to TAG_TOKEN. TAG_TOKEN was not added to the ci-release step env since nothing there consumes it.
- check-gate already had both `contents: read` and `checks: read`, so no permissions change was needed.
- ran golangci-lint fmt (make format's gosimports tool isn't installed); gci produced no import reordering, so no .go files changed.