### PR TITLE
fix: keep multi-line provider records at their own log level

### DIFF
--- a/cmd/grype-db/cli/internal/providers/external/log_writer.go
+++ b/cmd/grype-db/cli/internal/providers/external/log_writer.go
@@ -18,11 +18,18 @@ var (
 
 type logWriter struct {
 	name string
+
+	// lastLevel is the level of the most recent line that carried one. A
+	// multi-line record -- a python traceback is the common case -- only marks
+	// its first line, so the continuation lines are attributed to it rather
+	// than silently dropping to the default level.
+	lastLevel string
 }
 
 func newLogWriter(name string) *logWriter {
 	return &logWriter{
-		name: name,
+		name:      name,
+		lastLevel: defaultLogLevel,
 	}
 }
 
@@ -74,26 +81,32 @@ func processLogLine(line string) (string, string) {
 
 	level, ok := groups["level"]
 	if !ok || level == "" {
-		return defaultLogLevel, line
+		return "", line
 	}
 
 	prefix, ok := groups["prefix"]
 	if !ok {
-		return defaultLogLevel, line
+		return "", line
 	}
 
 	suffix, ok := groups["suffix"]
 	if !ok {
-		return defaultLogLevel, line
+		return "", line
 	}
 
 	message := fmt.Sprintf("%s%s", prefix, suffix)
 	return strings.ToUpper(level), message
 }
 
-func (lw logWriter) Write(p []byte) (n int, err error) {
+func (lw *logWriter) Write(p []byte) (n int, err error) {
 	for _, line := range strings.Split(string(p), "\n") {
 		level, line := processLogLine(line)
+		if level == "" {
+			// the line carries no level of its own: it continues the previous record
+			level = lw.lastLevel
+		} else {
+			lw.lastLevel = level
+		}
 		if line != "" {
 			message := fmt.Sprintf("[%s]", lw.name) + line
 

--- a/cmd/grype-db/cli/internal/providers/external/log_writer_test.go
+++ b/cmd/grype-db/cli/internal/providers/external/log_writer_test.go
@@ -1,9 +1,15 @@
 package external
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/go-logger"
+	"github.com/anchore/go-logger/adapter/discard"
+	"github.com/anchore/grype-db/internal/log"
 )
 
 func TestLogWriter_processLogLine(t *testing.T) {
@@ -14,9 +20,12 @@ func TestLogWriter_processLogLine(t *testing.T) {
 		expectedMessage string
 	}{
 		{
-			name:            "default log level",
+			// processLogLine reports "no level in this line" as an empty string; the
+			// writer is what turns that into the default level (or the level of the
+			// record the line continues).
+			name:            "no log level",
 			line:            `\033[0maggregating vulnerability data providers=[rhel]`,
-			expectedLevel:   defaultLogLevel,
+			expectedLevel:   "",
 			expectedMessage: `\033[0maggregating vulnerability data providers=[rhel]`,
 		},
 		{
@@ -64,4 +73,58 @@ func TestLogWriter_processLogLine(t *testing.T) {
 			assert.Equal(t, message, test.expectedMessage)
 		})
 	}
+}
+
+// captureLogger records the level each message was logged at.
+type captureLogger struct {
+	logger.Logger
+	entries []loggedEntry
+}
+
+type loggedEntry struct {
+	level   string
+	message string
+}
+
+func (c *captureLogger) record(level string, args ...any) {
+	c.entries = append(c.entries, loggedEntry{level: level, message: fmt.Sprint(args...)})
+}
+
+func (c *captureLogger) Error(args ...any) { c.record("ERROR", args...) }
+func (c *captureLogger) Warn(args ...any)  { c.record("WARN", args...) }
+func (c *captureLogger) Info(args ...any)  { c.record("INFO", args...) }
+func (c *captureLogger) Debug(args ...any) { c.record("DEBUG", args...) }
+func (c *captureLogger) Trace(args ...any) { c.record("TRACE", args...) }
+
+// TestLogWriter_multiLineRecordKeepsLevel covers a python traceback coming from a
+// provider: only its first line carries [ERROR], so the remaining lines used to
+// be logged at the default info level and disappeared from an error-level view
+// of the run.
+func TestLogWriter_multiLineRecordKeepsLevel(t *testing.T) {
+	capture := &captureLogger{Logger: discard.New()}
+	log.Set(capture)
+
+	lw := newLogWriter("nvd")
+
+	output := `[ERROR] nvd: error during pull
+Traceback (most recent call last):
+  File "/src/vunnel/cli/cli.py", line 100, in run
+    provider.run()
+ConnectionError: HTTPSConnectionPool(host='services.nvd.nist.gov', port=443)
+[INFO ] nvd: wrote 0 entries
+`
+
+	_, err := lw.Write([]byte(output))
+	require.NoError(t, err)
+
+	var levels []string
+	for _, e := range capture.entries {
+		levels = append(levels, e.level)
+	}
+
+	assert.Equal(t,
+		[]string{"ERROR", "ERROR", "ERROR", "ERROR", "ERROR", "INFO"},
+		levels,
+		"every line of the traceback should stay at the level of the record it belongs to, and a later line with its own level should reset it",
+	)
 }


### PR DESCRIPTION
Fixes #181

## Problem

A provider marks only the **first** line of a multi-line record with a level. For a python traceback coming out of vunnel that means:

```
[ERROR] nvd: error during pull          <- logged at error
Traceback (most recent call last):      <- no level in the line ...
  File "/src/vunnel/cli/cli.py", ...    <- ... so each of these falls
    provider.run()                      <- ... back to the default,
ConnectionError: HTTPSConnectionPool... <- ... which is info
```

So an error-level view of a run shows that a provider failed but not why — the traceback, which is the whole reason to look, is filed under info.

## Change

`logWriter` remembers the level of the last line that declared one and applies it to the lines that follow, until another line declares its own. A traceback stays with the record it belongs to, and the `[INFO ]` line after it resets the level as expected.

Two supporting changes:

- `processLogLine` now reports "this line carries no level" as an empty string rather than returning `defaultLogLevel`. The distinction matters: with the old signature an unmarked continuation line and an explicit `[INFO ]` line were indistinguishable, so the writer had nothing to work with. The existing test case for that path is updated to the new contract (renamed to "no log level"), and the observable behaviour is unchanged — a single unmarked line is still logged at info, because that is the level the writer starts with.
- `Write` takes a pointer receiver, so the remembered level survives between lines. `newLogWriter` already returned `*logWriter`, so no call site changes.

## Tests

`TestLogWriter_multiLineRecordKeepsLevel` drives a real traceback through `Write` with the logger captured, and asserts the level of every emitted line:

```go
[]string{"ERROR", "ERROR", "ERROR", "ERROR", "ERROR", "INFO"}
```

i.e. the whole traceback stays at error and the following `[INFO ]` line resets it.

Verified the test pins the behaviour — against `log_writer.go` as it is on `main`:

```
FAIL	github.com/anchore/grype-db/cmd/grype-db/cli/internal/providers/external	0.117s
```

and with the change, the whole package passes:

```
--- PASS: TestLogWriter_processLogLine (all 7 subtests)
--- PASS: TestLogWriter_multiLineRecordKeepsLevel
ok  	github.com/anchore/grype-db/cmd/grype-db/cli/internal/providers/external	0.128s
```
