### PR TITLE
feat: register cpan provider in nightly db build

### DIFF
--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -18,6 +18,7 @@ provider:
     - name: bitnami
     - name: chainguard
     - name: chainguard-libraries
+    - name: cpan
     - name: debian
     - name: echo
     - name: eol


### PR DESCRIPTION
Adds `cpan` to the provider list for the nightly publish, so perl advisories make it into the shipped database.

Deliberately not added to the `expected-providers` validation gate. CPANSA is a curated subset rather than a feed with guaranteed output, so gating on it would hard-fail the nightly the first day it yields no records. Worth revisiting once there is a sense of how often that happens.

Needs the cpan provider to exist on the vunnel side first.