### PR TITLE
feat: enable DHI advisory provider

### DIFF
--- a/config/grype-db-manager/include.d/validate.yaml
+++ b/config/grype-db-manager/include.d/validate.yaml
@@ -14,6 +14,7 @@ expected-providers:
   - chainguard
   - chainguard-libraries
   - debian
+  - dhi
   - echo
   - epss
   - github

--- a/config/grype-db/publish-nightly-r2.yaml
+++ b/config/grype-db/publish-nightly-r2.yaml
@@ -19,6 +19,7 @@ provider:
     - name: chainguard
     - name: chainguard-libraries
     - name: debian
+    - name: dhi
     - name: echo
     - name: eol
     - name: epss


### PR DESCRIPTION
Enables Docker Hardened Images (`dhi`) as a provider in the nightly Grype database pipeline and adds it to the database manager's expected-provider validation.

This completes the activation path across three repositories:

- anchore/vunnel#1293 adds the provider that clones [`docker-hardened-images/advisories`](https://github.com/docker-hardened-images/advisories), validates OSV records under `osv/dhi`, and publishes the DHI provider snapshot.
- anchore/grype#3613 adds the DHI OSV transformer, first-class `dhi` distro handling, release isolation, and native APK/Debian version matching.
- This PR schedules the DHI provider for the daily data sync and requires it to be present in published database validation.

This PR should remain draft until the Vunnel and Grype changes have merged and been released. Before activation, grype-db must also be updated to a Grype release containing anchore/grype#3613; otherwise the database builder will not recognize `DHI-` records. Enabling expected-provider validation also assumes the canonical advisory repository contains publishable DHI records.

## Testing

- `git diff --check origin/main...HEAD`
- Parsed both modified configuration files with `yaml.safe_load`

The earlier Go test run passed the affected packages; unrelated environment-dependent suites required a local `zstd` executable and a prebuilt CLI snapshot binary.